### PR TITLE
added include for bitlocker status

### DIFF
--- a/Public/Get/Devices/Get-NinjaOneDeviceVolumes.ps1
+++ b/Public/Get/Devices/Get-NinjaOneDeviceVolumes.ps1
@@ -15,7 +15,9 @@ function Get-NinjaOneDeviceVolumes {
         # Device ID
         [Parameter(ValueFromPipelineByPropertyName, Mandatory)]
         [Alias('id')]
-        [Int]$deviceID
+        [Int]$deviceID,
+        # Additional information to include (bl - BitLocker status)
+        [String]$include
     )
     $CommandName = $MyInvocation.InvocationName
     $Parameters = (Get-Command -Name $CommandName).Parameters


### PR DESCRIPTION
This adds the ability to view bitlocker status.
```
Get-NinjaOneDeviceVolumes -deviceID 70 -include bitlocker

name            : C:
driveLetter     : C:
label           :
deviceType      : Local Disk
fileSystem      : NTFS
autoMount       : True
compressed      : False
capacity        : 126533939200
freeSpace       : 73634189312
serialNumber    : 1EF0E336
bitLockerStatus : @{conversionStatus=FULLY_ENCRYPTED; encryptionMethod=XTS_AES_256; protectionStatus=PROTECTED;
                  lockStatus=LOCKED; initializedForProtection=True}
```