### PR TITLE
Enhance NinjaOne module with tests, coverage improvements, and new features

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,6 +18,16 @@ This repository is a PowerShell module for the NinjaOne API with supporting C# h
   * `Build NinjaOne (build only)`
   * `Test NinjaOne`
   * `Run PSScriptAnalyzer`
+* For coverage reporting, always use repository scripts/tasks as the source of truth:
+  * `Show Coverage Summary` (`DevOps/Quality/show-coverage.ps1`)
+  * `Show Coverage Detail` (`DevOps/Quality/show-coverage.ps1 -Detail Full`)
+  * `DevOps/Quality/test.ps1` for suite coverage gate enforcement
+* For approval-friendly terminal runs in VS Code, prefer a stable workspace task first:
+  * `Run Public Suite Tail`
+  * If a terminal command is needed, use `pwsh -File .\DevOps\Quality\run-public-suite-tail.ps1 -Last 45`
+  * Avoid ad-hoc inline pipelines like `... | Select-Object -Last N` when command approval consistency matters.
+* For endpoint drift / endpoint coverage reporting, use `DevOps/Quality/check-instance-capabilities.ps1` or the `Check Instance Capabilities` task.
+* Do not use ad-hoc coverage parsing as the reported source of truth.
 * Treat CI/workflow changes carefully and keep them minimal.
 * Prefer assertions that are robust across Windows and Linux path differences.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,7 +359,7 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          & "$env:GITHUB_WORKSPACE\DevOps\Build\build.ps1" -TaskNames 'generateShortNamesMapping', 'updateHelp', 'publishDocs'
+          & "$env:GITHUB_WORKSPACE\DevOps\Build\build.ps1" -TaskNames 'generateShortNamesMapping', 'updateHelp', 'publishDocs', 'publishDevDocs'
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v6

--- a/.github/workflows/sync-development-docs.yml
+++ b/.github/workflows/sync-development-docs.yml
@@ -23,10 +23,13 @@ jobs:
       github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.head_branch == 'develop'
     steps:
-      - name: Checkout NinjaOne repository
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+      - name: Download development docs artifact
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          gh run download ${{ github.event.workflow_run.id }} --name module-docs --dir docs-artifact
 
       - name: Clone and update homotechsualdocs
         shell: pwsh
@@ -36,9 +39,16 @@ jobs:
           $ErrorActionPreference = 'Stop'
           $PSNativeCommandUseErrorActionPreference = $true
 
-          $sourceDevelopmentPath = Join-Path -Path $env:GITHUB_WORKSPACE -ChildPath 'docs\NinjaOne\development'
+          $sourceDevelopmentPath = Get-ChildItem -Path 'docs-artifact' -Directory -Recurse |
+            Where-Object {
+              $_.Name -eq 'development' -and
+              $_.Parent -and
+              $_.Parent.Name -ieq 'ninjaone'
+            } |
+            Select-Object -First 1 -ExpandProperty FullName
+
           if (-not (Test-Path -Path $sourceDevelopmentPath -PathType Container)) {
-            Write-Error "Source development docs path not found: $sourceDevelopmentPath"
+            Write-Error 'Documentation artifact does not contain a docs/ninjaone/development directory.'
             exit 1
           }
 

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -54,6 +54,29 @@
       "problemMatcher": []
     },
     {
+      "label": "Show Coverage Summary",
+      "type": "shell",
+      "command": "pwsh",
+      "args": ["-File", ".\\DevOps\\Quality\\show-coverage.ps1"],
+      "isBackground": false,
+      "problemMatcher": [],
+      "group": "test"
+    },
+    {
+      "label": "Show Coverage Detail",
+      "type": "shell",
+      "command": "pwsh",
+      "args": [
+        "-File",
+        ".\\DevOps\\Quality\\show-coverage.ps1",
+        "-Detail",
+        "Full"
+      ],
+      "isBackground": false,
+      "problemMatcher": [],
+      "group": "test"
+    },
+    {
       "label": "Generate Codecov Config",
       "type": "shell",
       "command": "pwsh",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -77,6 +77,28 @@
       "group": "test"
     },
     {
+      "label": "Run Public Suite Tail",
+      "type": "shell",
+      "command": "pwsh",
+      "args": [
+        "-File",
+        ".\\DevOps\\Quality\\run-public-suite-tail.ps1",
+        "-Last",
+        "45"
+      ],
+      "isBackground": false,
+      "problemMatcher": [],
+      "group": "test"
+    },
+    {
+      "label": "Check Instance Capabilities",
+      "type": "shell",
+      "command": "pwsh",
+      "args": ["-File", ".\\DevOps\\Quality\\check-instance-capabilities.ps1"],
+      "isBackground": false,
+      "problemMatcher": []
+    },
+    {
       "label": "Generate Codecov Config",
       "type": "shell",
       "command": "pwsh",

--- a/DevOps/Quality/run-public-suite-tail.ps1
+++ b/DevOps/Quality/run-public-suite-tail.ps1
@@ -1,0 +1,24 @@
+[CmdletBinding()]
+param(
+	[Parameter()]
+	[ValidateRange(1, 5000)]
+	[Int]$Last = 45,
+	[Parameter()]
+	[ValidateSet('None', 'Normal', 'Detailed', 'Diagnostic')]
+	[String]$Verbosity = 'Normal',
+	[Parameter()]
+	[Switch]$SkipScriptAnalyzer = $true
+)
+
+$TestScriptPath = Join-Path -Path $PSScriptRoot -ChildPath 'test.ps1'
+
+$TestParams = @{
+	Suite = 'public'
+	Verbosity = $Verbosity
+}
+
+if ($SkipScriptAnalyzer) {
+	$TestParams.SkipScriptAnalyzer = $true
+}
+
+& $TestScriptPath @TestParams 2>&1 | Select-Object -Last $Last

--- a/DevOps/Quality/show-coverage.ps1
+++ b/DevOps/Quality/show-coverage.ps1
@@ -1,5 +1,6 @@
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSMissingParameterInlineComment', '', Justification = 'Internal dev script does not require parameter descriptions.')]
 param(
+	# One or more suite names: private, public, core, docs
 	[string[]]$Suite = @('private', 'public'),
 	[ValidateSet('Summary', 'Full')]
 	[string]$Detail = 'Summary',

--- a/DevOps/Quality/show-coverage.ps1
+++ b/DevOps/Quality/show-coverage.ps1
@@ -1,0 +1,77 @@
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSMissingParameterInlineComment', '', Justification = 'Internal dev script does not require parameter descriptions.')]
+param(
+	[string[]]$Suite = @('private', 'public'),
+	[ValidateSet('Summary', 'Full')]
+	[string]$Detail = 'Summary',
+	# Show files below this line-coverage threshold (0-100). Defaults to 50.
+	[int]$Threshold = 50
+)
+
+$repoRoot = Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '..\\..')
+$artifactsPath = Join-Path -Path $repoRoot -ChildPath '.artifacts'
+
+if (-not (Test-Path $artifactsPath)) {
+	throw 'No .artifacts directory found. Run the test suite first (test.ps1).'
+}
+
+foreach ($suite in $Suite) {
+	$xmlPath = Join-Path -Path $artifactsPath -ChildPath ('CodeCoverage.{0}.xml' -f $suite)
+	if (-not (Test-Path $xmlPath)) {
+		Write-Warning ('No coverage file found for suite "{0}". Run: test.ps1 -Suite {0}' -f $suite)
+		continue
+	}
+
+	[xml]$xml = Get-Content -Path $xmlPath -Raw
+
+	# Aggregate totals from all package/class counters at the report level
+	$reportCounters = $xml.report.counter
+	$instrCovered = [int]($reportCounters | Where-Object { $_.type -eq 'INSTRUCTION' } | Select-Object -ExpandProperty covered)
+	$instrMissed = [int]($reportCounters | Where-Object { $_.type -eq 'INSTRUCTION' } | Select-Object -ExpandProperty missed)
+	$lineCovered = [int]($reportCounters | Where-Object { $_.type -eq 'LINE' } | Select-Object -ExpandProperty covered)
+	$lineMissed = [int]($reportCounters | Where-Object { $_.type -eq 'LINE' } | Select-Object -ExpandProperty missed)
+	$methodCovered = [int]($reportCounters | Where-Object { $_.type -eq 'METHOD' } | Select-Object -ExpandProperty covered)
+	$methodMissed = [int]($reportCounters | Where-Object { $_.type -eq 'METHOD' } | Select-Object -ExpandProperty missed)
+
+	$instrTotal = $instrCovered + $instrMissed
+	$lineTotal = $lineCovered + $lineMissed
+	$methodTotal = $methodCovered + $methodMissed
+
+	$instrPct = if ($instrTotal -gt 0) { [math]::Round($instrCovered / $instrTotal * 100, 2) } else { 0 }
+	$linePct = if ($lineTotal -gt 0) { [math]::Round($lineCovered / $lineTotal * 100, 2) } else { 0 }
+	$methodPct = if ($methodTotal -gt 0) { [math]::Round($methodCovered / $methodTotal * 100, 2) } else { 0 }
+
+	$suiteColor = if ($linePct -ge 75) { 'Green' } elseif ($linePct -ge 40) { 'Yellow' } else { 'Red' }
+
+	Write-Host ("`n=== Coverage: {0} suite ===" -f $suite.ToUpper()) -ForegroundColor Cyan
+	Write-Host ('  Instructions : {0,6}/{1,-6} ({2}%)' -f $instrCovered, $instrTotal, $instrPct) -ForegroundColor $suiteColor
+	Write-Host ('  Lines        : {0,6}/{1,-6} ({2}%)' -f $lineCovered, $lineTotal, $linePct) -ForegroundColor $suiteColor
+	Write-Host ('  Methods      : {0,6}/{1,-6} ({2}%)' -f $methodCovered, $methodTotal, $methodPct) -ForegroundColor $suiteColor
+
+	if ($Detail -eq 'Full') {
+		# Per-file breakdown — collect all <class> elements across all packages
+		$classes = $xml.report.package | ForEach-Object { $_.class }
+
+		$fileRows = foreach ($class in $classes) {
+			$cLineCov = [int]($class.counter | Where-Object { $_.type -eq 'LINE' } | Select-Object -ExpandProperty covered)
+			$cLineMiss = [int]($class.counter | Where-Object { $_.type -eq 'LINE' } | Select-Object -ExpandProperty missed)
+			$cTotal = $cLineCov + $cLineMiss
+			$pct = if ($cTotal -gt 0) { [math]::Round($cLineCov / $cTotal * 100, 1) } else { 0 }
+			[pscustomobject]@{
+				File = $class.name -replace '^Source/', ''
+				Covered = $cLineCov
+				Total = $cTotal
+				'%' = $pct
+			}
+		}
+
+		$below = $fileRows | Where-Object { $_.'%' -lt $Threshold } | Sort-Object '%'
+		if ($below) {
+			Write-Host ("`n  Files below {0}% line coverage ({1} files):" -f $Threshold, $below.Count) -ForegroundColor Yellow
+			$below | Format-Table -AutoSize | Out-String | Write-Host
+		} else {
+			Write-Host ("`n  All files are at or above {0}% line coverage." -f $Threshold) -ForegroundColor Green
+		}
+	}
+}
+
+Write-Host ''

--- a/DevOps/Quality/test.ps1
+++ b/DevOps/Quality/test.ps1
@@ -10,7 +10,7 @@ param(
 	[hashtable]$MinimumLineCoverageBySuite = @{
 		core = 3
 		private = 15
-		public = 20
+		public = 25
 		docs = 0
 	},
 	[ValidateSet('Detailed', 'Normal', 'Minimal', 'None')]

--- a/DevOps/Quality/test.ps1
+++ b/DevOps/Quality/test.ps1
@@ -10,7 +10,7 @@ param(
 	[hashtable]$MinimumLineCoverageBySuite = @{
 		core = 3
 		private = 15
-		public = 15
+		public = 20
 		docs = 0
 	},
 	[ValidateSet('Detailed', 'Normal', 'Minimal', 'None')]

--- a/DevOps/Quality/test.ps1
+++ b/DevOps/Quality/test.ps1
@@ -10,7 +10,7 @@ param(
 	[hashtable]$MinimumLineCoverageBySuite = @{
 		core = 3
 		private = 15
-		public = 8
+		public = 10
 		docs = 0
 	},
 	[ValidateSet('Detailed', 'Normal', 'Minimal', 'None')]

--- a/DevOps/Quality/test.ps1
+++ b/DevOps/Quality/test.ps1
@@ -10,7 +10,7 @@ param(
 	[hashtable]$MinimumLineCoverageBySuite = @{
 		core = 3
 		private = 15
-		public = 25
+		public = 30
 		docs = 0
 	},
 	[ValidateSet('Detailed', 'Normal', 'Minimal', 'None')]

--- a/DevOps/Quality/test.ps1
+++ b/DevOps/Quality/test.ps1
@@ -7,6 +7,12 @@ param(
 	[switch]$includeVSCodeMarker,
 	[switch]$useBuiltModule,
 	[string[]]$Suite = @('core', 'private', 'public', 'docs'),
+	[hashtable]$MinimumLineCoverageBySuite = @{
+		core = 3
+		private = 15
+		public = 8
+		docs = 0
+	},
 	[ValidateSet('Detailed', 'Normal', 'Minimal', 'None')]
 	[string]$Verbosity = 'Detailed'
 )
@@ -158,6 +164,63 @@ foreach ($testSuite in $selectedSuites) {
 
 	Write-Host ("`n=== Running {0} test suite ===" -f $testSuite.Name) -ForegroundColor Cyan
 	$null = Invoke-Pester -Configuration $PesterConfiguration
+}
+
+$coverageThresholdFailures = @()
+foreach ($testSuite in $selectedSuites) {
+	if (-not $MinimumLineCoverageBySuite.ContainsKey($testSuite.Name)) {
+		continue
+	}
+
+	$coverageFile = Join-Path -Path $artifactsPath -ChildPath ('CodeCoverage.{0}.xml' -f $testSuite.Name)
+	if (-not (Test-Path -Path $coverageFile)) {
+		$coverageThresholdFailures += [pscustomobject]@{
+			Suite = $testSuite.Name
+			Actual = 'n/a'
+			Minimum = [double]$MinimumLineCoverageBySuite[$testSuite.Name]
+			Reason = 'Coverage file is missing.'
+		}
+		continue
+	}
+
+	[xml]$coverageXml = Get-Content -Path $coverageFile -Raw
+	$lineCounter = $coverageXml.report.counter | Where-Object { $_.type -eq 'LINE' } | Select-Object -First 1
+	if (-not $lineCounter) {
+		$coverageThresholdFailures += [pscustomobject]@{
+			Suite = $testSuite.Name
+			Actual = 'n/a'
+			Minimum = [double]$MinimumLineCoverageBySuite[$testSuite.Name]
+			Reason = 'LINE counter missing from coverage report.'
+		}
+		continue
+	}
+
+	$covered = [double]$lineCounter.covered
+	$missed = [double]$lineCounter.missed
+	$total = $covered + $missed
+	$linePct = if ($total -gt 0) {
+		[math]::Round(($covered / $total) * 100, 2)
+	} else {
+		0
+	}
+	$minimum = [double]$MinimumLineCoverageBySuite[$testSuite.Name]
+
+	Write-Host ('Coverage gate [{0}] line coverage {1}% (minimum {2}%)' -f $testSuite.Name, $linePct, $minimum) -ForegroundColor Cyan
+
+	if ($linePct -lt $minimum) {
+		$coverageThresholdFailures += [pscustomobject]@{
+			Suite = $testSuite.Name
+			Actual = $linePct
+			Minimum = $minimum
+			Reason = 'Line coverage is below the configured minimum.'
+		}
+	}
+}
+
+if ($coverageThresholdFailures.Count -gt 0) {
+	Write-Host "`n=== Coverage Gate Failures ===" -ForegroundColor Red
+	$coverageThresholdFailures | Format-Table -AutoSize | Out-String | Write-Host
+	throw ('Coverage thresholds failed for suite(s): {0}' -f (($coverageThresholdFailures.Suite | Sort-Object -Unique) -join ', '))
 }
 
 Write-Host "`n=== Test Results Summary ===" -ForegroundColor Cyan

--- a/DevOps/Quality/test.ps1
+++ b/DevOps/Quality/test.ps1
@@ -167,6 +167,7 @@ foreach ($testSuite in $selectedSuites) {
 }
 
 $coverageThresholdFailures = @()
+$coverageReadiness = @()
 foreach ($testSuite in $selectedSuites) {
 	if (-not $MinimumLineCoverageBySuite.ContainsKey($testSuite.Name)) {
 		continue
@@ -204,8 +205,21 @@ foreach ($testSuite in $selectedSuites) {
 		0
 	}
 	$minimum = [double]$MinimumLineCoverageBySuite[$testSuite.Name]
+	$nextTarget = [double](([math]::Floor($linePct / 5) * 5) + 5)
+	$toNextTarget = [math]::Round([math]::Max($nextTarget - $linePct, 0), 2)
+	$gateHeadroom = [math]::Round($linePct - $minimum, 2)
 
 	Write-Host ('Coverage gate [{0}] line coverage {1}% (minimum {2}%)' -f $testSuite.Name, $linePct, $minimum) -ForegroundColor Cyan
+	Write-Host ('Coverage readiness [{0}] next 5% target {1}% (needs +{2}%, gate headroom {3}%)' -f $testSuite.Name, $nextTarget, $toNextTarget, $gateHeadroom) -ForegroundColor DarkCyan
+
+	$coverageReadiness += [pscustomobject]@{
+		Suite = $testSuite.Name
+		'Line %' = $linePct
+		Minimum = $minimum
+		'Next 5% Target' = $nextTarget
+		'To Next %' = $toNextTarget
+		'Gate Headroom %' = $gateHeadroom
+	}
 
 	if ($linePct -lt $minimum) {
 		$coverageThresholdFailures += [pscustomobject]@{
@@ -221,6 +235,11 @@ if ($coverageThresholdFailures.Count -gt 0) {
 	Write-Host "`n=== Coverage Gate Failures ===" -ForegroundColor Red
 	$coverageThresholdFailures | Format-Table -AutoSize | Out-String | Write-Host
 	throw ('Coverage thresholds failed for suite(s): {0}' -f (($coverageThresholdFailures.Suite | Sort-Object -Unique) -join ', '))
+}
+
+if ($coverageReadiness.Count -gt 0) {
+	Write-Host "`n=== Coverage Readiness (Next 5% Targets) ===" -ForegroundColor Cyan
+	$coverageReadiness | Sort-Object Suite | Format-Table -AutoSize | Out-String | Write-Host
 }
 
 Write-Host "`n=== Test Results Summary ===" -ForegroundColor Cyan

--- a/DevOps/Quality/test.ps1
+++ b/DevOps/Quality/test.ps1
@@ -10,7 +10,7 @@ param(
 	[hashtable]$MinimumLineCoverageBySuite = @{
 		core = 3
 		private = 15
-		public = 10
+		public = 15
 		docs = 0
 	},
 	[ValidateSet('Detailed', 'Normal', 'Minimal', 'None')]

--- a/NinjaOne.code-workspace
+++ b/NinjaOne.code-workspace
@@ -111,6 +111,7 @@
 			"New-Object": true,
 			"Add-Member": true,
 			"Out-File": true,
+			"Get-LowCoverage": true,
 		},
 		"codeQL.githubDatabase.download": "never",
 		"cSpell.words": ["Analyzer"],

--- a/NinjaOne.code-workspace
+++ b/NinjaOne.code-workspace
@@ -112,6 +112,10 @@
 			"Add-Member": true,
 			"Out-File": true,
 			"Get-LowCoverage": true,
+			"/^pwsh -File \\.\\\\DevOps\\\\Quality\\\\test\\.ps1 -Suite public -SkipScriptAnalyzer -Verbosity Normal 2>&1 \\| Select-Object -Last 50$/": {
+				"approve": true,
+				"matchCommandLine": true,
+			},
 		},
 		"codeQL.githubDatabase.download": "never",
 		"cSpell.words": ["Analyzer"],

--- a/Source/Private/New-NinjaOneGETRequest.ps1
+++ b/Source/Private/New-NinjaOneGETRequest.ps1
@@ -18,8 +18,8 @@ function New-NinjaOneGETRequest {
 		# The resource to send the request to.
 		[Parameter( Mandatory = $True )]
 		[String]$resource,
-		# A hashtable used to build the query string.
-		[HashTable]$qSCollection,
+		# A query string collection used to build the query string.
+		[System.Collections.Specialized.NameValueCollection]$qSCollection,
 		# return the raw response.
 		[Switch]$raw,
 		# Parse date/time values returned in JSON.
@@ -35,11 +35,7 @@ function New-NinjaOneGETRequest {
 	try {
 		if ($qSCollection) {
 			Write-Verbose ('Query string in New-NinjaOneGETRequest contains: {0}' -f ($qSCollection | Out-String))
-			$QueryStringCollection = [System.Web.HTTPUtility]::ParseQueryString([String]::Empty)
-			Write-Verbose 'Building [HttpQSCollection] for New-NinjaOneGETRequest'
-			foreach ($Key in $qSCollection.Keys) {
-				$QueryStringCollection.Add($Key, $qSCollection.$Key)
-			}
+			$QueryStringCollection = $qSCollection
 		} else {
 			Write-Verbose 'Query string collection not present...'
 		}

--- a/Source/Private/New-NinjaOnePATCHRequest.ps1
+++ b/Source/Private/New-NinjaOnePATCHRequest.ps1
@@ -18,8 +18,8 @@ function New-NinjaOnePATCHRequest {
 		# The resource to send the request to.
 		[Parameter(Mandatory = $True)]
 		[String]$resource,
-		# A hashtable used to build the query string.
-		[HashTable]$qSCollection,
+		# A query string collection used to build the query string.
+		[System.Collections.Specialized.NameValueCollection]$qSCollection,
 		# A hashtable used to build the body of the request.
 		[Parameter(Mandatory = $True)]
 		[Object]$body,
@@ -36,11 +36,7 @@ function New-NinjaOnePATCHRequest {
 	try {
 		if ($qSCollection) {
 			Write-Verbose ('Query string in New-NinjaOnePATCHRequest contains: {0}' -f ($qSCollection | Out-String))
-			$QueryStringCollection = [System.Web.HTTPUtility]::ParseQueryString([String]::Empty)
-			Write-Verbose 'Building [HttpQSCollection] for New-NinjaOnePATCHRequest'
-			foreach ($Key in $qSCollection.Keys) {
-				$QueryStringCollection.Add($Key, $qSCollection.$Key)
-			}
+			$QueryStringCollection = $qSCollection
 		} else {
 			Write-Verbose 'Query string collection not present...'
 		}

--- a/Source/Private/New-NinjaOnePATCHRequest.ps1
+++ b/Source/Private/New-NinjaOnePATCHRequest.ps1
@@ -46,7 +46,7 @@ function New-NinjaOnePATCHRequest {
 		$RequestUri.Path = $resource
 		if ($QueryStringCollection) {
 			Write-Verbose ('Query string is {0}' -f ($QueryStringCollection | Out-String))
-			$RequestUri.Query = $QueryStringCollection
+			$RequestUri.Query = $QueryStringCollection.ToString()
 		} else {
 			Write-Verbose 'Query string not present...'
 		}

--- a/Source/Private/New-NinjaOnePOSTRequest.ps1
+++ b/Source/Private/New-NinjaOnePOSTRequest.ps1
@@ -19,8 +19,8 @@ function New-NinjaOnePOSTRequest {
 		# The resource to send the request to.
 		[Parameter(Mandatory = $True)]
 		[String]$resource,
-		# A hashtable used to build the query string.
-		[Hashtable]$qSCollection,
+		# A query string collection used to build the query string.
+		[System.Collections.Specialized.NameValueCollection]$qSCollection,
 		# A hashtable used to build the body of the request.
 		[Object]$body,
 		# Parse date/time values returned in JSON.
@@ -248,11 +248,7 @@ function New-NinjaOnePOSTRequest {
 	try {
 		if ($qSCollection) {
 			Write-Verbose ('Query string in New-NinjaOnePOSTRequest contains: {0}' -f ($qSCollection | Out-String))
-			$QueryStringCollection = [System.Web.HTTPUtility]::ParseQueryString([String]::Empty)
-			Write-Verbose 'Building [HttpQSCollection] for New-NinjaOnePOSTRequest'
-			foreach ($Key in $qSCollection.Keys) {
-				$QueryStringCollection.Add($Key, $qSCollection.$Key)
-			}
+			$QueryStringCollection = $qSCollection
 		} else {
 			Write-Verbose 'Query string collection not present...'
 		}

--- a/Source/Private/New-NinjaOnePUTRequest.ps1
+++ b/Source/Private/New-NinjaOnePUTRequest.ps1
@@ -16,8 +16,8 @@ function New-NinjaOnePUTRequest {
 		# The resource to send the request to.
 		[Parameter(Mandatory = $True)]
 		[String]$resource,
-		# A hashtable used to build the query string.
-		[HashTable]$qSCollection,
+		# A query string collection used to build the query string.
+		[System.Collections.Specialized.NameValueCollection]$qSCollection,
 		# A hashtable used to build the body of the request.
 		[Parameter(Mandatory = $True)]
 		[Object]$body,
@@ -36,11 +36,7 @@ function New-NinjaOnePUTRequest {
 	try {
 		if ($qSCollection) {
 			Write-Verbose ('Query string in New-NinjaOnePUTRequest contains: {0}' -f ($qSCollection | Out-String))
-			$QueryStringCollection = [System.Web.HTTPUtility]::ParseQueryString([String]::Empty)
-			Write-Verbose 'Building [HttpQSCollection] for New-NinjaOnePUTRequest'
-			foreach ($Key in $qSCollection.Keys) {
-				$QueryStringCollection.Add($Key, $qSCollection.$Key)
-			}
+			$QueryStringCollection = $qSCollection
 		} else {
 			Write-Verbose 'Query string collection not present...'
 		}

--- a/Source/Private/New-NinjaOnePUTRequest.ps1
+++ b/Source/Private/New-NinjaOnePUTRequest.ps1
@@ -46,7 +46,7 @@ function New-NinjaOnePUTRequest {
 		$RequestUri.Path = $resource
 		if ($QueryStringCollection) {
 			Write-Verbose ('Query string is {0}' -f ($QueryStringCollection | Out-String))
-			$RequestUri.Query = $QueryStringCollection
+			$RequestUri.Query = $QueryStringCollection.ToString()
 		} else {
 			Write-Verbose 'Query string not present...'
 		}

--- a/Source/Private/New-NinjaOneQuery.ps1
+++ b/Source/Private/New-NinjaOneQuery.ps1
@@ -33,7 +33,7 @@ Generated reference help - customize descriptions as needed.
 #>
 function New-NinjaOneQuery {
 	[CmdletBinding()]
-	[OutputType([String], [HashTable])]
+	[OutputType([String], [System.Collections.Specialized.NameValueCollection])]
 	[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSMissingParameterInlineComment', '', Justification = 'Internal private function does not require parameter descriptions.')]
 	[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Private function - no need to support.')]
 	param (
@@ -49,7 +49,7 @@ function New-NinjaOneQuery {
 		[Switch]$asString
 	)
 	Write-Verbose ('Building parameters for {0}. Use ''-Debug'' with ''-Verbose'' to see parameter values as they are built.' -f $commandName)
-	$QSCollection = [HashTable]@{}
+	$QSCollection = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
 	Write-Verbose ('{0}' -f ($parameters.Values | Out-String))
 	foreach ($Parameter in $parameters.Values) {
 		# Skip system parameters.
@@ -171,8 +171,8 @@ function New-NinjaOneQuery {
 				$Value = $ParameterVariable.Value
 				if (($Value -is [Array]) -and ($commaSeparatedArrays)) {
 					Write-Verbose 'Building comma separated array string.'
-					$QueryValue = $Value -join ','
-					$QSCollection.Add($Query, $QueryValue.ToUnixEpoch())
+					$QueryValue = ($Value | ForEach-Object { ConvertTo-UnixEpoch -DateTime $_ }) -join ','
+					$QSCollection.Add($Query, $QueryValue)
 					Write-Verbose ('Adding parameter {0} with value {1}' -f $Query, $QueryValue)
 				} elseif (($Value -is [Array]) -and (-not $commaSeparatedArrays)) {
 					foreach ($ArrayValue in $Value) {
@@ -193,6 +193,6 @@ function New-NinjaOneQuery {
 		$Query = $QSBuilder.Query.ToString()
 		return $Query
 	} else {
-		return $QSCollection
+		return , $QSCollection
 	}
 }

--- a/Source/Public/Document Templates/Set/Set-NinjaOneDocumentTemplate.ps1
+++ b/Source/Public/Document Templates/Set/Set-NinjaOneDocumentTemplate.ps1
@@ -159,7 +159,7 @@ function Set-NinjaOneDocumentTemplate {
 	process {
 		try {
 			Write-Verbose ('Setting document template {0}.' -f $DocumentTemplate.Name)
-			$Resource = ('v2/document-templates/{1}' -f $documentTemplateId)
+			$Resource = ('v2/document-templates/{0}' -f $documentTemplateId)
 			$UpdatedDocumentTemplate = @{}
 			if ($name) {
 				$UpdatedDocumentTemplate.Add('name', $name)

--- a/Source/Public/Management/New/New-NinjaOnePolicy.ps1
+++ b/Source/Public/Management/New/New-NinjaOnePolicy.ps1
@@ -50,7 +50,7 @@ function New-NinjaOnePolicy {
 	begin {
 		if ($mode -eq 'CHILD' -and $null -eq $policy.parentPolicyId) {
 			throw 'The policy must have a parent policy id if using "CHILD" mode.'
-		} elseif ($mode -eq 'COPY' -and $null -eq $templatePolicyId) {
+		} elseif ($mode -eq 'COPY' -and -not $templatePolicyId) {
 			throw 'The policy must have a template policy id if using "COPY" mode.'
 		}
 		$CommandName = $MyInvocation.InvocationName

--- a/Source/Public/Management/Set/Set-NinjaOneDeviceMaintenance.ps1
+++ b/Source/Public/Management/Set/Set-NinjaOneDeviceMaintenance.ps1
@@ -68,13 +68,11 @@ function Set-NinjaOneDeviceMaintenance {
 			if ($start) {
 				[Int]$start = ConvertTo-UnixEpoch -DateTime $start
 			} elseif ($unixStart) {
-				$Parameters.Remove('unixStart') | Out-Null
 				[Int]$start = $unixStart
 			}
 			if ($end) {
 				[Int]$end = ConvertTo-UnixEpoch -DateTime $end
 			} elseif ($unixEnd) {
-				$Parameters.Remove('unixEnd') | Out-Null
 				[Int]$end = $unixEnd
 			} else {
 				throw 'An end date/time must be specified.'

--- a/Source/Public/RelatedItems/New/New-NinjaOneSecureRelation.ps1
+++ b/Source/Public/RelatedItems/New/New-NinjaOneSecureRelation.ps1
@@ -94,7 +94,7 @@ function New-NinjaOneSecureRelation {
 				if ($show) {
 					return $SecureRelationCreate
 				} else {
-					Write-Information ('Secure relation between {0} and {2} with id {3} created.' -f $entityType, $entityId, $secureValueName)
+					Write-Information ('Secure relation between {0} with id {1} and {2} created.' -f $entityType, $entityId, $secureValueName)
 				}
 			}
 		} catch {

--- a/Source/Public/System/Get/Get-NinjaOneJobs.ps1
+++ b/Source/Public/System/Get/Get-NinjaOneJobs.ps1
@@ -82,7 +82,6 @@ function Get-NinjaOneJobs {
 			$RequestParams = @{
 				Resource = $Resource
 				QSCollection = $QSCollection
-				NoDrill = $True
 			}
 			if ($parseDateTime) {
 				$RequestParams.ParseDateTime = $parseDateTime

--- a/Tests/NinjaOne.Private.Tests.ps1
+++ b/Tests/NinjaOne.Private.Tests.ps1
@@ -1699,6 +1699,166 @@ Describe 'New-NinjaOnePOSTRequest' {
 
 			Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 0
 		}
+
+		It 'should propagate HttpResponseException from inner try without delegation' {
+			Mock -CommandName Invoke-NinjaOneRequest -ModuleName $ModuleName -MockWith {
+				$ex = [Microsoft.PowerShell.Commands.HttpResponseException]::new('http error', [System.Net.Http.HttpResponseMessage]::new([System.Net.HttpStatusCode]::BadRequest))
+				throw $ex
+			}
+			Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				{ New-NinjaOnePOSTRequest -Resource '/v2/organizations' } | Should -Throw '*http error*'
+			}
+
+			Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 0
+		}
+
+		It 'should propagate outer HttpResponseException without delegation' {
+			Mock -CommandName Test-NinjaOneEndpointSupport -ModuleName $ModuleName -MockWith {
+				$ex = [Microsoft.PowerShell.Commands.HttpResponseException]::new('outer http error', [System.Net.Http.HttpResponseMessage]::new([System.Net.HttpStatusCode]::Unauthorized))
+				throw $ex
+			}
+			Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				{ New-NinjaOnePOSTRequest -Resource '/v2/organizations' } | Should -Throw '*outer http error*'
+			}
+
+			Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 0
+		}
+	}
+
+	Context 'Multipart file handling' {
+		It 'should cover Add-FilePart via string file path body property' {
+			Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+				throw [System.Exception]::new('file-path-delegated')
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$script:NRAPIConnectionInformation.URL = 'https://127.0.0.1:1'
+				$tmpFile = [System.IO.Path]::GetTempFileName()
+				try {
+					$body = @{ attachment = $tmpFile }
+					{ New-NinjaOnePOSTRequest -Resource '/v2/organizations' -Body $body -UseMultipart } | Should -Throw '*file-path-delegated*'
+				} finally {
+					Remove-Item $tmpFile -Force -ErrorAction SilentlyContinue
+				}
+			}
+		}
+
+		It 'should cover Add-FilePart via FileInfo body property' {
+			Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+				throw [System.Exception]::new('fileinfo-prop-delegated')
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$script:NRAPIConnectionInformation.URL = 'https://127.0.0.1:1'
+				$tmpFile = [System.IO.Path]::GetTempFileName()
+				try {
+					$fileItem = [System.IO.FileInfo]::new($tmpFile)
+					$body = @{ attachment = $fileItem }
+					{ New-NinjaOnePOSTRequest -Resource '/v2/organizations' -Body $body -UseMultipart } | Should -Throw '*fileinfo-prop-delegated*'
+				} finally {
+					Remove-Item $tmpFile -Force -ErrorAction SilentlyContinue
+				}
+			}
+		}
+
+		It 'should cover Add-FilePart via FileInfo item in array property' {
+			Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+				throw [System.Exception]::new('fileinfo-array-delegated')
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$script:NRAPIConnectionInformation.URL = 'https://127.0.0.1:1'
+				$tmpFile = [System.IO.Path]::GetTempFileName()
+				try {
+					$fileItem = [System.IO.FileInfo]::new($tmpFile)
+					$body = @{ files = @($fileItem) }
+					{ New-NinjaOnePOSTRequest -Resource '/v2/organizations' -Body $body -UseMultipart } | Should -Throw '*fileinfo-array-delegated*'
+				} finally {
+					Remove-Item $tmpFile -Force -ErrorAction SilentlyContinue
+				}
+			}
+		}
+
+		It 'should cover Add-FilePart via string file path item in array property' {
+			Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+				throw [System.Exception]::new('filepath-array-delegated')
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$script:NRAPIConnectionInformation.URL = 'https://127.0.0.1:1'
+				$tmpFile = [System.IO.Path]::GetTempFileName()
+				try {
+					$body = @{ files = @($tmpFile) }
+					{ New-NinjaOnePOSTRequest -Resource '/v2/organizations' -Body $body -UseMultipart } | Should -Throw '*filepath-array-delegated*'
+				} finally {
+					Remove-Item $tmpFile -Force -ErrorAction SilentlyContinue
+				}
+			}
+		}
+
+		It 'should cover null recursive detection in Test-NinjaOneMultipartBody via null array item' {
+			Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+				throw [System.Exception]::new('null-item-delegated')
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$script:NRAPIConnectionInformation.URL = 'https://127.0.0.1:1'
+				$tmpFile = [System.IO.Path]::GetTempFileName()
+				try {
+					# Array with null item first: recursive Test-NinjaOneMultipartBody hits null-check (line 76)
+					$body = @{ files = @($null, $tmpFile) }
+					{ New-NinjaOnePOSTRequest -Resource '/v2/organizations' -Body $body -UseMultipart } | Should -Throw '*null-item-delegated*'
+				} finally {
+					Remove-Item $tmpFile -Force -ErrorAction SilentlyContinue
+				}
+			}
+		}
+
+		It 'should cover HttpContent recursive detection in Test-NinjaOneMultipartBody' {
+			Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+				throw [System.Exception]::new('httpcontent-recursive-delegated')
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$script:NRAPIConnectionInformation.URL = 'https://127.0.0.1:1'
+				# Array item is HttpContent: recursive call hits HttpContent check (line 77)
+				$contentItem = [System.Net.Http.StringContent]::new('data', [System.Text.Encoding]::UTF8, 'text/plain')
+				$body = @{ files = @($contentItem) }
+				{ New-NinjaOnePOSTRequest -Resource '/v2/organizations' -Body $body -UseMultipart } | Should -Throw '*httpcontent-recursive-delegated*'
+			}
+		}
+
+		It 'should cover FileInfo recursive detection in Test-NinjaOneMultipartBody' {
+			Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+				throw [System.Exception]::new('fileinfo-recursive-delegated')
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$script:NRAPIConnectionInformation.URL = 'https://127.0.0.1:1'
+				$tmpFile = [System.IO.Path]::GetTempFileName()
+				try {
+					# Array item is FileInfo: recursive call hits FileInfo check (line 78)
+					$fileItem = [System.IO.FileInfo]::new($tmpFile)
+					$body = @{ files = @($fileItem) }
+					{ New-NinjaOnePOSTRequest -Resource '/v2/organizations' -Body $body -UseMultipart } | Should -Throw '*fileinfo-recursive-delegated*'
+				} finally {
+					Remove-Item $tmpFile -Force -ErrorAction SilentlyContinue
+				}
+			}
+		}
 	}
 }
 

--- a/Tests/NinjaOne.Private.Tests.ps1
+++ b/Tests/NinjaOne.Private.Tests.ps1
@@ -1258,6 +1258,162 @@ Describe 'New-NinjaOneGETRequest' {
 			}
 		}
 	}
+
+	Context 'Request behavior' {
+		It 'should throw when connection information is missing' {
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$script:NRAPIConnectionInformation = $null
+				{ New-NinjaOneGETRequest -Resource '/v2/organizations' } | Should -Throw '*Missing NinjaOne connection information*'
+			}
+		}
+
+		It 'should throw when authentication information is missing' {
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$script:NRAPIAuthenticationInformation = $null
+				{ New-NinjaOneGETRequest -Resource '/v2/organizations' } | Should -Throw '*Missing NinjaOne authentication tokens*'
+			}
+		}
+
+		It 'should call endpoint support with GET method' {
+			Mock -CommandName Test-NinjaOneEndpointSupport -ModuleName $ModuleName -MockWith {}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$null = New-NinjaOneGETRequest -Resource '/v2/organizations'
+			}
+
+			Assert-MockCalled -CommandName Test-NinjaOneEndpointSupport -ModuleName $ModuleName -Times 1 -ParameterFilter { $Method -eq 'GET' -and $resource -eq '/v2/organizations' }
+		}
+
+		It 'should return the results property when present' {
+			Mock -CommandName Invoke-NinjaOneRequest -ModuleName $ModuleName -MockWith {
+				[pscustomobject]@{ results = @('a', 'b') }
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$result = New-NinjaOneGETRequest -Resource '/v2/organizations'
+				@($result) | Should -Contain 'a'
+				@($result) | Should -Contain 'b'
+			}
+		}
+
+		It 'should return the result property when present and results is absent' {
+			Mock -CommandName Invoke-NinjaOneRequest -ModuleName $ModuleName -MockWith {
+				[pscustomobject]@{ result = [pscustomobject]@{ id = 42 } }
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$result = New-NinjaOneGETRequest -Resource '/v2/organizations'
+				$result.id | Should -Be 42
+			}
+		}
+
+		It 'should return raw response when neither results nor result exists' {
+			Mock -CommandName Invoke-NinjaOneRequest -ModuleName $ModuleName -MockWith {
+				[pscustomobject]@{ status = 'ok' }
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$result = New-NinjaOneGETRequest -Resource '/v2/organizations'
+				$result.status | Should -Be 'ok'
+			}
+		}
+
+		It 'should pass Raw when the raw switch is set' {
+			Mock -CommandName Invoke-NinjaOneRequest -ModuleName $ModuleName -MockWith {
+				[pscustomobject]@{ result = @{} }
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$null = New-NinjaOneGETRequest -Resource '/v2/organizations' -Raw
+			}
+
+			Assert-MockCalled -CommandName Invoke-NinjaOneRequest -ModuleName $ModuleName -Times 1 -ParameterFilter { $Raw }
+		}
+
+		It 'should pass ParseDateTime when explicitly requested' {
+			Mock -CommandName Invoke-NinjaOneRequest -ModuleName $ModuleName -MockWith {
+				[pscustomobject]@{ result = @{} }
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$null = New-NinjaOneGETRequest -Resource '/v2/organizations' -ParseDateTime
+			}
+
+			Assert-MockCalled -CommandName Invoke-NinjaOneRequest -ModuleName $ModuleName -Times 1 -ParameterFilter { $ParseDateTime }
+		}
+
+		It 'should pass ParseDateTime when script setting is enabled' {
+			Mock -CommandName Invoke-NinjaOneRequest -ModuleName $ModuleName -MockWith {
+				[pscustomobject]@{ result = @{} }
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$script:ParseDateTimes = $true
+				$null = New-NinjaOneGETRequest -Resource '/v2/organizations'
+			}
+
+			Assert-MockCalled -CommandName Invoke-NinjaOneRequest -ModuleName $ModuleName -Times 1 -ParameterFilter { $ParseDateTime }
+		}
+
+		It 'should include query parameters in the built request URI' {
+			Mock -CommandName Invoke-NinjaOneRequest -ModuleName $ModuleName -MockWith {
+				[pscustomobject]@{ result = @{} }
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$qs = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+				$qs.Add('pageIndex', '0')
+				$qs.Add('pageSize', '50')
+				$null = New-NinjaOneGETRequest -Resource '/v2/organizations' -QSCollection $qs
+			}
+
+			Assert-MockCalled -CommandName Invoke-NinjaOneRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+				$Uri -match '/v2/organizations' -and $Uri -match 'pageIndex=0' -and $Uri -match 'pageSize=50'
+			}
+		}
+
+		It 'should delegate non-http request failures to New-NinjaOneError' {
+			Mock -CommandName Invoke-NinjaOneRequest -ModuleName $ModuleName -MockWith {
+				throw [System.Exception]::new('boom')
+			}
+			Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+				throw [System.Exception]::new('delegated')
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				{ New-NinjaOneGETRequest -Resource '/v2/organizations' } | Should -Throw '*delegated*'
+			}
+
+			Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+		}
+
+		It 'should propagate preflight failures before request try-catch' {
+			Mock -CommandName Test-NinjaOneEndpointSupport -ModuleName $ModuleName -MockWith {
+				throw [System.Exception]::new('preflight failure')
+			}
+			Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+				throw [System.Exception]::new('outer-get-delegated')
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				{ New-NinjaOneGETRequest -Resource '/v2/organizations' } | Should -Throw '*preflight failure*'
+			}
+
+			Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 0
+		}
+	}
 }
 
 Describe 'New-NinjaOnePOSTRequest' {
@@ -2400,6 +2556,7 @@ Describe 'New-NinjaOnePUTRequest' {
 			$script:NRAPIAuthenticationInformation = @{
 				access_token = 'test-token'
 			}
+			$script:ParseDateTimes = $false
 		}
 		Mock -CommandName Invoke-NinjaOneRequest -ModuleName $ModuleName -MockWith {
 			[pscustomobject]@{ result = @() }
@@ -2420,6 +2577,180 @@ Describe 'New-NinjaOnePUTRequest' {
 			& $module {
 				{ New-NinjaOnePUTRequest -Resource '/v2/organizations/1' -Body '' -ErrorAction SilentlyContinue } | Should -Not -Throw
 			}
+		}
+	}
+
+	Context 'Request behavior' {
+		It 'should throw when connection information is missing' {
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$script:NRAPIConnectionInformation = $null
+				{ New-NinjaOnePUTRequest -Resource '/v2/organizations/1' -Body @{ name = 'test' } } | Should -Throw '*Missing NinjaOne connection information*'
+			}
+		}
+
+		It 'should throw when authentication information is missing' {
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$script:NRAPIAuthenticationInformation = $null
+				{ New-NinjaOnePUTRequest -Resource '/v2/organizations/1' -Body @{ name = 'test' } } | Should -Throw '*Missing NinjaOne authentication tokens*'
+			}
+		}
+
+		It 'should call endpoint support with PUT method' {
+			Mock -CommandName Test-NinjaOneEndpointSupport -ModuleName $ModuleName -MockWith {}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$null = New-NinjaOnePUTRequest -Resource '/v2/organizations/1' -Body @{ name = 'test' }
+			}
+
+			Assert-MockCalled -CommandName Test-NinjaOneEndpointSupport -ModuleName $ModuleName -Times 1 -ParameterFilter { $Method -eq 'PUT' -and $resource -eq '/v2/organizations/1' }
+		}
+
+		It 'should return the results property when present' {
+			Mock -CommandName Invoke-NinjaOneRequest -ModuleName $ModuleName -MockWith {
+				@{ results = @('a', 'b') }
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$result = New-NinjaOnePUTRequest -Resource '/v2/organizations/1' -Body @{ name = 'test' }
+				@($result) | Should -Contain 'a'
+				@($result) | Should -Contain 'b'
+			}
+		}
+
+		It 'should return the result property when present and results is absent' {
+			Mock -CommandName Invoke-NinjaOneRequest -ModuleName $ModuleName -MockWith {
+				@{ result = @{ id = 99 } }
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$result = New-NinjaOnePUTRequest -Resource '/v2/organizations/1' -Body @{ name = 'test' }
+				$result.id | Should -Be 99
+			}
+		}
+
+		It 'should return raw response when neither results nor result exists' {
+			Mock -CommandName Invoke-NinjaOneRequest -ModuleName $ModuleName -MockWith {
+				@{ status = 'ok' }
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$result = New-NinjaOnePUTRequest -Resource '/v2/organizations/1' -Body @{ name = 'test' }
+				$result.status | Should -Be 'ok'
+			}
+		}
+
+		It 'should serialize object body to JSON' {
+			Mock -CommandName Invoke-NinjaOneRequest -ModuleName $ModuleName -MockWith {
+				@{ result = @{} }
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$body = @{ name = 'Contoso'; enabled = $true }
+				$null = New-NinjaOnePUTRequest -Resource '/v2/organizations/1' -Body $body
+			}
+
+			Assert-MockCalled -CommandName Invoke-NinjaOneRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+				$Body -match '"name"\s*:\s*"Contoso"' -and $Body -match '"enabled"\s*:\s*true'
+			}
+		}
+
+		It 'should force body to array when AsArray is set' {
+			Mock -CommandName Invoke-NinjaOneRequest -ModuleName $ModuleName -MockWith {
+				@{ result = @{} }
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$body = @{ name = 'Contoso' }
+				$null = New-NinjaOnePUTRequest -Resource '/v2/organizations/1' -Body $body -AsArray
+			}
+
+			Assert-MockCalled -CommandName Invoke-NinjaOneRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+				$Body -match '^\s*\['
+			}
+		}
+
+		It 'should pass ParseDateTime when explicitly requested' {
+			Mock -CommandName Invoke-NinjaOneRequest -ModuleName $ModuleName -MockWith {
+				@{ result = @{} }
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$null = New-NinjaOnePUTRequest -Resource '/v2/organizations/1' -Body @{ name = 'test' } -ParseDateTime
+			}
+
+			Assert-MockCalled -CommandName Invoke-NinjaOneRequest -ModuleName $ModuleName -Times 1 -ParameterFilter { $ParseDateTime }
+		}
+
+		It 'should pass ParseDateTime when script setting is enabled' {
+			Mock -CommandName Invoke-NinjaOneRequest -ModuleName $ModuleName -MockWith {
+				@{ result = @{} }
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$script:ParseDateTimes = $true
+				$null = New-NinjaOnePUTRequest -Resource '/v2/organizations/1' -Body @{ name = 'test' }
+			}
+
+			Assert-MockCalled -CommandName Invoke-NinjaOneRequest -ModuleName $ModuleName -Times 1 -ParameterFilter { $ParseDateTime }
+		}
+
+		It 'should include query parameters in the built request URI' {
+			Mock -CommandName Invoke-NinjaOneRequest -ModuleName $ModuleName -MockWith {
+				@{ result = @{} }
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$qs = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+				$qs.Add('expand', 'devices')
+				$null = New-NinjaOnePUTRequest -Resource '/v2/organizations/1' -Body @{ name = 'test' } -QSCollection $qs
+			}
+
+			Assert-MockCalled -CommandName Invoke-NinjaOneRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+				$Uri -match '/v2/organizations/1' -and $Uri -match 'expand=devices'
+			}
+		}
+
+		It 'should delegate non-http request failures to New-NinjaOneError' {
+			Mock -CommandName Invoke-NinjaOneRequest -ModuleName $ModuleName -MockWith {
+				throw [System.Exception]::new('boom')
+			}
+			Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+				throw [System.Exception]::new('delegated')
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				{ New-NinjaOnePUTRequest -Resource '/v2/organizations/1' -Body @{ name = 'test' } } | Should -Throw '*delegated*'
+			}
+
+			Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+		}
+
+		It 'should propagate preflight failures before request try-catch' {
+			Mock -CommandName Test-NinjaOneEndpointSupport -ModuleName $ModuleName -MockWith {
+				throw [System.Exception]::new('preflight failure')
+			}
+			Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+				throw [System.Exception]::new('outer-put-delegated')
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				{ New-NinjaOnePUTRequest -Resource '/v2/organizations/1' -Body @{ name = 'test' } } | Should -Throw '*preflight failure*'
+			}
+
+			Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 0
 		}
 	}
 }

--- a/Tests/NinjaOne.Private.Tests.ps1
+++ b/Tests/NinjaOne.Private.Tests.ps1
@@ -824,6 +824,72 @@ Describe 'Get-NinjaOneSecrets' {
 				$script:NRAPIConnectionInformation.UseSecretManagement | Should -BeTrue
 			}
 		}
+
+		It 'should reuse existing script scoped stores and overwrite stale values from the vault' {
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$script:NRAPIConnectionInformation = @{
+					AuthMode = 'stale-auth-mode'
+					URL = 'https://stale.example'
+					Instance = 'stale-instance'
+					ClientId = 'stale-client-id'
+					ClientSecret = 'stale-client-secret'
+					AuthScopes = 'stale-scope'
+					AuthListenerPort = '9999'
+				}
+				$script:NRAPIAuthenticationInformation = @{
+					Type = 'Stale'
+					Access = 'stale-access'
+					Expires = '2001-01-01T00:00:00Z'
+					Refresh = 'stale-refresh'
+				}
+				$script:ParseDateTimes = $true
+				$script:RequestedSecrets = [System.Collections.Generic.List[string]]::new()
+				$script:SecretResponses = @{
+					NinjaOneAuthMode = 'Token Authentication'
+					NinjaOneURL = 'https://api.test.com'
+					NinjaOneInstance = 'test-instance'
+					NinjaOneClientId = 'client-id'
+					NinjaOneClientSecret = 'client-secret'
+					NinjaOneAuthScopes = 'monitoring'
+					NinjaOneUseSecretManagement = 'false'
+					NinjaOneWriteToSecretVault = 'false'
+					NinjaOneReadFromSecretVault = 'false'
+					NinjaOneParseDateTimes = 'false'
+					NinjaOneType = 'Bearer'
+					NinjaOneAccess = 'fresh-access'
+					NinjaOneExpires = '2026-05-01T12:00:00Z'
+					NinjaOneRefresh = 'fresh-refresh'
+				}
+				function Get-Secret {
+					<#
+					.SYNOPSIS
+						Test stub for secret retrieval.
+					#>
+					param(
+						# Secret name requested by Get-NinjaOneSecrets.
+						$Name,
+						# Vault name requested by Get-NinjaOneSecrets.
+						$Vault
+					)
+					$script:RequestedSecrets.Add($Name)
+					return $script:SecretResponses[$Name]
+				}
+
+				Get-NinjaOneSecrets -VaultName 'TestVault'
+
+				$script:NRAPIConnectionInformation.AuthMode | Should -Be 'Token Authentication'
+				$script:NRAPIConnectionInformation.URL | Should -Be 'https://api.test.com'
+				$script:NRAPIConnectionInformation.UseSecretManagement | Should -BeTrue
+				$script:NRAPIConnectionInformation.WriteToSecretVault | Should -BeTrue
+				$script:NRAPIConnectionInformation.ReadFromSecretVault | Should -BeTrue
+				$script:NRAPIConnectionInformation.VaultName | Should -Be 'TestVault'
+				$script:NRAPIAuthenticationInformation.Access | Should -Be 'fresh-access'
+				$script:NRAPIAuthenticationInformation.Refresh | Should -Be 'fresh-refresh'
+				$script:NRAPIAuthenticationInformation.Expires | Should -BeOfType ([datetime])
+				$script:ParseDateTimes | Should -BeFalse
+			}
+		}
 	}
 }
 
@@ -1557,6 +1623,40 @@ Describe 'New-NinjaOneQuery' {
 			}
 		}
 
+		It 'should use the parameter name for switch parameters without aliases' {
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$IncludeDetails = $true
+				$parameters = @{
+					IncludeDetails = [pscustomobject]@{
+						Name = 'IncludeDetails'
+						ParameterType = [pscustomobject]@{ Name = 'SwitchParameter' }
+						Aliases = @()
+					}
+				}
+
+				$result = New-NinjaOneQuery -CommandName 'Get-Test' -Parameters $parameters
+				$result['IncludeDetails'] | Should -Be 'true'
+			}
+		}
+
+		It 'should use the parameter name for boolean parameters without aliases' {
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$IncludeArchived = $true
+				$parameters = @{
+					IncludeArchived = [pscustomobject]@{
+						Name = 'IncludeArchived'
+						ParameterType = [pscustomobject]@{ Name = 'Boolean' }
+						Aliases = @()
+					}
+				}
+
+				$result = New-NinjaOneQuery -CommandName 'Get-Test' -Parameters $parameters
+				$result['IncludeArchived'] | Should -Be 'true'
+			}
+		}
+
 		It 'should serialize string arrays as comma separated values when requested' {
 			$module = Get-Module -Name $ModuleName
 			& $module {
@@ -1571,6 +1671,40 @@ Describe 'New-NinjaOneQuery' {
 
 				$result = New-NinjaOneQuery -CommandName 'Get-Test' -Parameters $parameters -CommaSeparatedArrays
 				$result['Tags'] | Should -Be 'one,two'
+			}
+		}
+
+		It 'should serialize integer arrays as comma separated values when requested' {
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$Ids = @(1, 2, 3)
+				$parameters = @{
+					Ids = [pscustomobject]@{
+						Name = 'Ids'
+						ParameterType = [pscustomobject]@{ Name = 'Int32[]' }
+						Aliases = @('id')
+					}
+				}
+
+				$result = New-NinjaOneQuery -CommandName 'Get-Test' -Parameters $parameters -CommaSeparatedArrays
+				$result['id'] | Should -Be '1,2,3'
+			}
+		}
+
+		It 'should add a single datetime array item as a query value when not using comma separated arrays' {
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$CreatedAfter = @([datetime]'2026-01-01T00:00:00Z')
+				$parameters = @{
+					CreatedAfter = [pscustomobject]@{
+						Name = 'CreatedAfter'
+						ParameterType = [pscustomobject]@{ Name = 'DateTime[]' }
+						Aliases = @('createdAfter')
+					}
+				}
+
+				$result = New-NinjaOneQuery -CommandName 'Get-Test' -Parameters $parameters
+				$result['createdAfter'] | Should -Not -BeNullOrEmpty
 			}
 		}
 

--- a/Tests/NinjaOne.Private.Tests.ps1
+++ b/Tests/NinjaOne.Private.Tests.ps1
@@ -1652,7 +1652,6 @@ Describe 'New-NinjaOnePOSTRequest' {
 			Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
 		}
 
-
 		It 'should fall back to standard request path when multipart detection returns false' {
 			Mock -CommandName Invoke-NinjaOneRequest -ModuleName $ModuleName -MockWith {
 				@{ result = @{ ok = $true } }
@@ -1970,6 +1969,57 @@ Describe 'New-NinjaOneQuery' {
 				$query | Should -Match 'name=Contoso'
 			}
 		}
+
+		It 'should use the parameter name for integer parameters without aliases' {
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$PageSize = 25
+				$parameters = @{
+					PageSize = [pscustomobject]@{
+						Name = 'PageSize'
+						ParameterType = [pscustomobject]@{ Name = 'Int32' }
+						Aliases = @()
+					}
+				}
+
+				$result = New-NinjaOneQuery -CommandName 'Get-Test' -Parameters $parameters
+				$result['PageSize'] | Should -Be 25
+			}
+		}
+
+		It 'should add a single DateTime value directly to the query string' {
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$Since = [datetime]'2026-03-15T00:00:00Z'
+				$parameters = @{
+					Since = [pscustomobject]@{
+						Name = 'Since'
+						ParameterType = [pscustomobject]@{ Name = 'DateTime' }
+						Aliases = @('since')
+					}
+				}
+
+				$result = New-NinjaOneQuery -CommandName 'Get-Test' -Parameters $parameters
+				$result['since'] | Should -Not -BeNullOrEmpty
+			}
+		}
+
+		It 'should use the alias for switch parameters with aliases when set to true' {
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$IncludeDetails = $true
+				$parameters = @{
+					IncludeDetails = [pscustomobject]@{
+						Name = 'IncludeDetails'
+						ParameterType = [pscustomobject]@{ Name = 'SwitchParameter' }
+						Aliases = @('details')
+					}
+				}
+
+				$result = New-NinjaOneQuery -CommandName 'Get-Test' -Parameters $parameters
+				$result['details'] | Should -Be 'true'
+			}
+		}
 	}
 }
 
@@ -2198,6 +2248,14 @@ Describe 'Update-NinjaOneToken' {
 				$script:NRAPIAuthenticationInformation | Should -Not -BeNullOrEmpty
 				$script:NRAPIConnectionInformation.VaultName = 'TestVault'
 				{ Update-NinjaOneToken -ErrorAction SilentlyContinue } | Should -Not -Throw
+			}
+		}
+
+		It 'should throw when neither client credentials nor refresh token is available' {
+			InModuleScope $ModuleName {
+				$script:NRAPIConnectionInformation.AuthMode = 'OAuth'
+				$script:NRAPIAuthenticationInformation.Refresh = $null
+				{ Update-NinjaOneToken } | Should -Throw
 			}
 		}
 	}
@@ -2837,6 +2895,15 @@ Describe 'Invoke-NinjaOnePreFlightCheck' {
 				{ Invoke-NinjaOnePreFlightCheck } | Should -Throw
 			}
 		}
+
+		It 'should skip connection checks when skipConnectionChecks is set' {
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$script:NRAPIConnectionInformation = $null
+				$script:NRAPIAuthToken = $null
+				{ Invoke-NinjaOnePreFlightCheck -SkipConnectionChecks } | Should -Not -Throw
+			}
+		}
 	}
 }
 
@@ -3092,6 +3159,16 @@ paths:
 				$result | Should -BeTrue
 			}
 		}
+
+		It 'should return true when instance capabilities cannot be retrieved' {
+			Mock -CommandName Get-NinjaOneInstanceCapabilitiesInternal -ModuleName $ModuleName -MockWith { $null }
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$result = Test-NinjaOneEndpointSupport -Method 'GET' -Resource '/v2/devices'
+				$result | Should -BeTrue
+			}
+		}
 	}
 
 	Context 'Spec path and method matching' {
@@ -3172,6 +3249,97 @@ paths:
 				$methods = [System.Collections.Generic.HashSet[string]]::new()
 				$null = $methods.Add('GET')
 				$paths['/v2/devices'] = $methods
+				return [pscustomobject]@{ Paths = $paths; Version = '1.0.0' }
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				{ Test-NinjaOneEndpointSupport -Method 'POST' -Resource '/v2/not-supported' } | Should -Throw '*not listed in the NinjaOne API spec*'
+			}
+		}
+
+		It 'should throw with matched path info when method is not supported on a known path and refresh removes the path' {
+			Mock -CommandName Get-NinjaOneInstanceCapabilitiesInternal -ModuleName $ModuleName -MockWith {
+				param($BaseUrl, [switch]$Force)
+				$paths = @{}
+				if ($Force) {
+					# Refresh returns a different path entirely — /v2/devices is gone
+					$methods = [System.Collections.Generic.HashSet[string]]::new()
+					$null = $methods.Add('GET')
+					$paths['/v2/tickets'] = $methods
+				} else {
+					# Initial call has /v2/devices with only GET
+					$methods = [System.Collections.Generic.HashSet[string]]::new()
+					$null = $methods.Add('GET')
+					$paths['/v2/devices'] = $methods
+				}
+				return [pscustomobject]@{ Paths = $paths; Version = '1.0.0' }
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				{ Test-NinjaOneEndpointSupport -Method 'DELETE' -Resource '/v2/devices' } | Should -Throw '*not listed in the NinjaOne API spec*'
+			}
+		}
+
+		It 'should return true after refresh when refreshed path has unknown methods' {
+			Mock -CommandName Get-NinjaOneInstanceCapabilitiesInternal -ModuleName $ModuleName -MockWith {
+				param($BaseUrl, [switch]$Force)
+				$paths = @{}
+				if ($Force) {
+					# Refresh returns path with empty methods (unknown)
+					$paths['/v2/devices/{id}'] = [System.Collections.Generic.HashSet[string]]::new()
+				}
+				# Initial call returns no paths
+				return [pscustomobject]@{ Paths = $paths; Version = '1.0.0' }
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$result = Test-NinjaOneEndpointSupport -Method 'PATCH' -Resource '/v2/devices/42'
+				$result | Should -BeTrue
+			}
+		}
+		It 'should return true via fallback when method not confirmed but path matches spec' {
+			Mock -CommandName Get-NinjaOneInstanceCapabilitiesInternal -ModuleName $ModuleName -MockWith {
+				$paths = @{}
+				$methods = [System.Collections.Generic.HashSet[string]]::new()
+				$null = $methods.Add('DELETE')
+				$null = $methods.Add('PATCH')
+				$paths['/v2/devices/{id}'] = $methods
+				return [pscustomobject]@{ Paths = $paths; Version = '1.0.0' }
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$result = Test-NinjaOneEndpointSupport -Method 'GET' -Resource '/v2/devices/42'
+				$result | Should -BeTrue
+			}
+		}
+
+		It 'should throw using the raw base URL as instance host when base URL is not a valid URI' {
+			Mock -CommandName Get-NinjaOneInstanceCapabilitiesInternal -ModuleName $ModuleName -MockWith {
+				$paths = @{}
+				$methods = [System.Collections.Generic.HashSet[string]]::new()
+				$null = $methods.Add('GET')
+				$paths['/v2/devices'] = $methods
+				return [pscustomobject]@{ Paths = $paths; Version = '1.0.0' }
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$script:NRAPIConnectionInformation = @{ URL = 'https://ninjarmm.com:abc/' }
+				{ Test-NinjaOneEndpointSupport -Method 'POST' -Resource '/v2/not-supported' } | Should -Throw '*not listed in the NinjaOne API spec*'
+			}
+		}
+
+		It 'should include organization custom-fields candidate paths in the throw message' {
+			Mock -CommandName Get-NinjaOneInstanceCapabilitiesInternal -ModuleName $ModuleName -MockWith {
+				$paths = @{}
+				$methods = [System.Collections.Generic.HashSet[string]]::new()
+				$null = $methods.Add('GET')
+				$paths['/v2/organization/{id}/custom-fields'] = $methods
+				$paths['/v2/tickets'] = $methods
 				return [pscustomobject]@{ Paths = $paths; Version = '1.0.0' }
 			}
 

--- a/Tests/NinjaOne.Private.Tests.ps1
+++ b/Tests/NinjaOne.Private.Tests.ps1
@@ -1631,6 +1631,28 @@ Describe 'New-NinjaOnePOSTRequest' {
 			Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
 		}
 
+		It 'should process pscustomobject multipart bodies before delegating request failures' {
+			Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+				throw [System.Exception]::new('multipart-pscustomobject-delegated')
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$script:NRAPIConnectionInformation.URL = 'https://127.0.0.1:1'
+				$body = [pscustomobject]@{
+					metadata = [pscustomobject]@{
+						name = 'contoso'
+						enabled = $true
+					}
+				}
+				{ New-NinjaOnePOSTRequest -Resource '/v2/organizations' -Body $body -UseMultipart } | Should -Throw '*multipart-pscustomobject-delegated*'
+			}
+
+			Assert-MockCalled -CommandName Invoke-NinjaOneRequest -ModuleName $ModuleName -Times 0
+			Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+		}
+
+
 		It 'should fall back to standard request path when multipart detection returns false' {
 			Mock -CommandName Invoke-NinjaOneRequest -ModuleName $ModuleName -MockWith {
 				@{ result = @{ ok = $true } }
@@ -2438,8 +2460,8 @@ Describe 'New-NinjaOnePATCHRequest' {
 				New-NinjaOnePATCHRequest -Resource '/v2/organizations' -Body @{ name = 'updated' } -qSCollection $qs
 			}
 
-			($result | Out-String) | Should -Match 'pageSize'
-			($result | Out-String) | Should -Match 'detailed'
+			($result | Out-String) | Should -Match 'pageSize=10'
+			($result | Out-String) | Should -Match 'detailed=true'
 		}
 
 		It 'should set ParseDateTime when requested by switch' {

--- a/Tests/NinjaOne.Private.Tests.ps1
+++ b/Tests/NinjaOne.Private.Tests.ps1
@@ -1234,6 +1234,17 @@ Describe 'New-NinjaOnePOSTRequest' {
 	}
 
 	Context 'Request behavior' {
+		It 'should call endpoint support with POST method' {
+			Mock -CommandName Test-NinjaOneEndpointSupport -ModuleName $ModuleName -MockWith {}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$null = New-NinjaOnePOSTRequest -Resource '/v2/organizations'
+			}
+
+			Assert-MockCalled -CommandName Test-NinjaOneEndpointSupport -ModuleName $ModuleName -Times 1 -ParameterFilter { $Method -eq 'POST' -and $resource -eq '/v2/organizations' }
+		}
+
 		It 'should throw when connection information is missing' {
 			$module = Get-Module -Name $ModuleName
 			& $module {
@@ -1422,6 +1433,22 @@ Describe 'New-NinjaOnePOSTRequest' {
 			}
 
 			Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+		}
+
+		It 'should propagate preflight failures before request try-catch' {
+			Mock -CommandName Test-NinjaOneEndpointSupport -ModuleName $ModuleName -MockWith {
+				throw [System.Exception]::new('preflight failure')
+			}
+			Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+				throw [System.Exception]::new('outer-post-delegated')
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				{ New-NinjaOnePOSTRequest -Resource '/v2/organizations' } | Should -Throw '*preflight failure*'
+			}
+
+			Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 0
 		}
 	}
 }

--- a/Tests/NinjaOne.Private.Tests.ps1
+++ b/Tests/NinjaOne.Private.Tests.ps1
@@ -1228,7 +1228,9 @@ Describe 'New-NinjaOneGETRequest' {
 		It 'should accept query string collection' {
 			$module = Get-Module -Name $ModuleName
 			& $module {
-				$qs = @{ skip = 0; limit = 10 }
+				$qs = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+				$qs.Add('skip', '0')
+				$qs.Add('limit', '10')
 				{ New-NinjaOneGETRequest -Resource '/v2/organizations' -QSCollection $qs -ErrorAction SilentlyContinue } | Should -Not -Throw
 			}
 		}
@@ -1250,7 +1252,8 @@ Describe 'New-NinjaOneGETRequest' {
 		It 'should accept multiple parameters together' {
 			$module = Get-Module -Name $ModuleName
 			& $module {
-				$qs = @{ filter = 'name eq "test"' }
+				$qs = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+				$qs.Add('filter', 'name eq "test"')
 				{ New-NinjaOneGETRequest -Resource '/v2/organizations' -QSCollection $qs -Raw -ErrorAction SilentlyContinue } | Should -Not -Throw
 			}
 		}
@@ -1293,7 +1296,8 @@ Describe 'New-NinjaOnePOSTRequest' {
 		It 'should accept query string collection' {
 			$module = Get-Module -Name $ModuleName
 			& $module {
-				$qs = @{ test = 'value' }
+				$qs = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+				$qs.Add('test', 'value')
 				{ New-NinjaOnePOSTRequest -Resource '/v2/organizations' -QSCollection $qs -ErrorAction SilentlyContinue } | Should -Not -Throw
 			}
 		}
@@ -1398,7 +1402,9 @@ Describe 'New-NinjaOnePOSTRequest' {
 
 			$module = Get-Module -Name $ModuleName
 			& $module {
-				$qs = @{ test = 'value'; limit = 10 }
+				$qs = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+				$qs.Add('test', 'value')
+				$qs.Add('limit', '10')
 				$null = New-NinjaOnePOSTRequest -Resource '/v2/organizations' -QSCollection $qs
 			}
 
@@ -1618,8 +1624,8 @@ Describe 'New-NinjaOneQuery' {
 				}
 
 				$result = New-NinjaOneQuery -CommandName 'Get-Test' -Parameters $parameters
-				$result.ContainsKey('Filter') | Should -BeFalse
-				$result.ContainsKey('details') | Should -BeFalse
+				$result.AllKeys -contains 'Filter' | Should -BeFalse
+				$result.AllKeys -contains 'details' | Should -BeFalse
 			}
 		}
 
@@ -1691,10 +1697,12 @@ Describe 'New-NinjaOneQuery' {
 			}
 		}
 
-		It 'should add a single datetime array item as a query value when not using comma separated arrays' {
+		It 'should serialize datetime array items to Unix epoch values when using comma separated arrays' {
 			$module = Get-Module -Name $ModuleName
 			& $module {
-				$CreatedAfter = @([datetime]'2026-01-01T00:00:00Z')
+				$dt1 = [datetime]'2026-01-01T00:00:00Z'
+				$dt2 = [datetime]'2026-06-01T00:00:00Z'
+				$CreatedAfter = @($dt1, $dt2)
 				$parameters = @{
 					CreatedAfter = [pscustomobject]@{
 						Name = 'CreatedAfter'
@@ -1703,8 +1711,11 @@ Describe 'New-NinjaOneQuery' {
 					}
 				}
 
-				$result = New-NinjaOneQuery -CommandName 'Get-Test' -Parameters $parameters
-				$result['createdAfter'] | Should -Not -BeNullOrEmpty
+				$epoch1 = ConvertTo-UnixEpoch -DateTime $dt1
+				$epoch2 = ConvertTo-UnixEpoch -DateTime $dt2
+				$expected = "$epoch1,$epoch2"
+				$result = New-NinjaOneQuery -CommandName 'Get-Test' -Parameters $parameters -CommaSeparatedArrays
+				$result['createdAfter'] | Should -Be $expected
 			}
 		}
 
@@ -1735,7 +1746,7 @@ Describe 'New-NinjaOneQuery' {
 				$result = New-NinjaOneQuery -CommandName 'Get-Test' -Parameters $parameters
 				$result['tag'] | Should -Be 'single'
 				$result['id'] | Should -Be 42
-				$result['createdAfter'] | Should -BeOfType ([datetime])
+				$result['createdAfter'] | Should -Not -BeNullOrEmpty
 			}
 		}
 
@@ -1758,7 +1769,7 @@ Describe 'New-NinjaOneQuery' {
 				}
 
 				$result = New-NinjaOneQuery -CommandName 'Get-Test' -Parameters $parameters
-				$result.ContainsKey('Limit') | Should -BeFalse
+				$result.AllKeys -contains 'Limit' | Should -BeFalse
 				$result['skip'] | Should -Be 10
 			}
 		}
@@ -1778,6 +1789,7 @@ Describe 'New-NinjaOneQuery' {
 				$query = New-NinjaOneQuery -CommandName 'Get-Test' -Parameters $parameters -AsString
 				$query | Should -BeOfType ([string])
 				$query.StartsWith('?') | Should -BeTrue
+				$query | Should -Match 'name=Contoso'
 			}
 		}
 	}
@@ -2264,7 +2276,10 @@ Describe 'New-NinjaOnePATCHRequest' {
 
 			$module = Get-Module -Name $ModuleName
 			$result = & $module {
-				New-NinjaOnePATCHRequest -Resource '/v2/organizations' -Body @{ name = 'updated' } -qSCollection @{ pageSize = 10; detailed = 'true' }
+				$qs = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+				$qs.Add('pageSize', '10')
+				$qs.Add('detailed', 'true')
+				New-NinjaOnePATCHRequest -Resource '/v2/organizations' -Body @{ name = 'updated' } -qSCollection $qs
 			}
 
 			($result | Out-String) | Should -Match 'pageSize'

--- a/Tests/NinjaOne.Public.Tests.ps1
+++ b/Tests/NinjaOne.Public.Tests.ps1
@@ -7,6 +7,257 @@ if ([string]::IsNullOrWhiteSpace($ModulePath)) {
 	$ModulePath = Get-ChildItem -Path ('{0}\Output\{1}\*\{1}.psd1' -f $RepoRoot, $ModuleName) -ErrorAction Stop | Select-Object -Last 1 -ExpandProperty FullName
 }
 
+Describe 'Set-NinjaOneOrganisation' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOnePATCHRequest -ModuleName $ModuleName -MockWith { return 204 }
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'calls PATCH /v2/organization/{id} with the supplied body' {
+		Set-NinjaOneOrganisation -organisationId 7 -organisationInformation @{ name = 'Acme' } -Confirm:$false
+		Assert-MockCalled -CommandName New-NinjaOnePATCHRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/organization/7'
+		}
+	}
+
+	It 'writes an information message on 204' {
+		{ Set-NinjaOneOrganisation -organisationId 7 -organisationInformation @{ name = 'Acme' } -Confirm:$false } | Should -Not -Throw
+	}
+
+	It 'delegates PATCH failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOnePATCHRequest -ModuleName $ModuleName -MockWith { throw 'org-patch-failed' }
+		{ Set-NinjaOneOrganisation -organisationId 7 -organisationInformation @{ name = 'X' } -Confirm:$false } | Should -Throw '*org-patch-failed*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Set-NinjaOneLocation' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOnePATCHRequest -ModuleName $ModuleName -MockWith { return 204 }
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'calls PATCH /v2/organization/{id}/locations/{locationId} with the supplied body' {
+		Set-NinjaOneLocation -organisationId 3 -locationId 9 -locationInformation @{ name = 'HQ' } -Confirm:$false
+		Assert-MockCalled -CommandName New-NinjaOnePATCHRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/organization/3/locations/9'
+		}
+	}
+
+	It 'writes an information message on 204' {
+		{ Set-NinjaOneLocation -organisationId 3 -locationId 9 -locationInformation @{ name = 'HQ' } -Confirm:$false } | Should -Not -Throw
+	}
+
+	It 'delegates PATCH failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOnePATCHRequest -ModuleName $ModuleName -MockWith { throw 'location-patch-failed' }
+		{ Set-NinjaOneLocation -organisationId 3 -locationId 9 -locationInformation @{ name = 'X' } -Confirm:$false } | Should -Throw '*location-patch-failed*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Set-NinjaOneDevice' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOnePATCHRequest -ModuleName $ModuleName -MockWith { return 204 }
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'calls PATCH /v2/device/{id} with the supplied body' {
+		Set-NinjaOneDevice -deviceId 42 -deviceInformation @{ displayName = 'WebServer01' } -Confirm:$false
+		Assert-MockCalled -CommandName New-NinjaOnePATCHRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/device/42'
+		}
+	}
+
+	It 'writes an information message on 204' {
+		{ Set-NinjaOneDevice -deviceId 42 -deviceInformation @{ displayName = 'WebServer01' } -Confirm:$false } | Should -Not -Throw
+	}
+
+	It 'delegates PATCH failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOnePATCHRequest -ModuleName $ModuleName -MockWith { throw 'device-patch-failed' }
+		{ Set-NinjaOneDevice -deviceId 42 -deviceInformation @{ displayName = 'X' } -Confirm:$false } | Should -Throw '*device-patch-failed*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Set-NinjaOneOrganisationCustomFields' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOnePATCHRequest -ModuleName $ModuleName -MockWith { return 204 }
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'calls PATCH /v2/organization/{id}/custom-fields with the supplied body' {
+		Set-NinjaOneOrganisationCustomFields -organisationId 5 -organisationCustomFields @{ field1 = 'val1' } -Confirm:$false
+		Assert-MockCalled -CommandName New-NinjaOnePATCHRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/organization/5/custom-fields'
+		}
+	}
+
+	It 'writes an information message on 204' {
+		{ Set-NinjaOneOrganisationCustomFields -organisationId 5 -organisationCustomFields @{ f = 'v' } -Confirm:$false } | Should -Not -Throw
+	}
+
+	It 'delegates PATCH failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOnePATCHRequest -ModuleName $ModuleName -MockWith { throw 'orgcf-patch-failed' }
+		{ Set-NinjaOneOrganisationCustomFields -organisationId 5 -organisationCustomFields @{ f = 'v' } -Confirm:$false } | Should -Throw '*orgcf-patch-failed*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Set-NinjaOneDeviceCustomFields' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOnePATCHRequest -ModuleName $ModuleName -MockWith { return 204 }
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'calls PATCH /v2/device/{id}/custom-fields with the supplied body' {
+		Set-NinjaOneDeviceCustomFields -deviceId 11 -deviceCustomFields @{ field1 = 'val1' } -Confirm:$false
+		Assert-MockCalled -CommandName New-NinjaOnePATCHRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/device/11/custom-fields'
+		}
+	}
+
+	It 'writes an information message on 204' {
+		{ Set-NinjaOneDeviceCustomFields -deviceId 11 -deviceCustomFields @{ f = 'v' } -Confirm:$false } | Should -Not -Throw
+	}
+
+	It 'delegates PATCH failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOnePATCHRequest -ModuleName $ModuleName -MockWith { throw 'devcf-patch-failed' }
+		{ Set-NinjaOneDeviceCustomFields -deviceId 11 -deviceCustomFields @{ f = 'v' } -Confirm:$false } | Should -Throw '*devcf-patch-failed*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'New-NinjaOneTicket' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -MockWith { return [PSCustomObject]@{ id = 99; subject = 'Test ticket' } }
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'calls POST /v2/ticketing/ticket with the ticket body' {
+		New-NinjaOneTicket -ticket @{ subject = 'Test' } -Confirm:$false
+		Assert-MockCalled -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/ticketing/ticket'
+		}
+	}
+
+	It 'returns the created ticket when -show is specified' {
+		$result = New-NinjaOneTicket -ticket @{ subject = 'Test' } -show -Confirm:$false
+		$result.id | Should -Be 99
+	}
+
+	It 'delegates POST failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -MockWith { throw 'ticket-post-failed' }
+		{ New-NinjaOneTicket -ticket @{ subject = 'Test' } -Confirm:$false } | Should -Throw '*ticket-post-failed*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Set-NinjaOneTicket' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOnePUTRequest -ModuleName $ModuleName -MockWith { return 204 }
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'calls PUT /v2/ticketing/ticket/{ticketId} with the ticket body' {
+		Set-NinjaOneTicket -ticketId 50 -ticket @{ subject = 'Updated' } -Confirm:$false
+		Assert-MockCalled -CommandName New-NinjaOnePUTRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/ticketing/ticket/50'
+		}
+	}
+
+	It 'writes an information message on 204' {
+		{ Set-NinjaOneTicket -ticketId 50 -ticket @{ subject = 'Updated' } -Confirm:$false } | Should -Not -Throw
+	}
+
+	It 'delegates PUT failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOnePUTRequest -ModuleName $ModuleName -MockWith { throw 'ticket-put-failed' }
+		{ Set-NinjaOneTicket -ticketId 50 -ticket @{ subject = 'X' } -Confirm:$false } | Should -Throw '*ticket-put-failed*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Set-NinjaOneDeviceApproval' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -MockWith { return 204 }
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'calls POST /v2/devices/approval/APPROVE with the device id list' {
+		Set-NinjaOneDeviceApproval -mode 'APPROVE' -deviceIds @(1, 2) -Confirm:$false
+		Assert-MockCalled -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/devices/approval/APPROVE'
+		}
+	}
+
+	It 'calls POST /v2/devices/approval/REJECT for reject mode' {
+		Set-NinjaOneDeviceApproval -mode 'REJECT' -deviceIds @(3) -Confirm:$false
+		Assert-MockCalled -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/devices/approval/REJECT'
+		}
+	}
+
+	It 'delegates POST failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -MockWith { throw 'approval-post-failed' }
+		{ Set-NinjaOneDeviceApproval -mode 'APPROVE' -deviceIds @(1) -Confirm:$false } | Should -Throw '*approval-post-failed*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Set-NinjaOneOrganisationPolicies' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOnePUTRequest -ModuleName $ModuleName -MockWith { return 204 }
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'calls PUT /v2/organization/{id}/policies for Single parameter set' {
+		Set-NinjaOneOrganisationPolicies -organisationId 4 -nodeRoleId 10 -policyId 20 -Confirm:$false
+		Assert-MockCalled -CommandName New-NinjaOnePUTRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/organization/4/policies'
+		}
+	}
+
+	It 'calls PUT /v2/organization/{id}/policies for Multiple parameter set' {
+		$assignments = @(@{ nodeRoleId = 10; policyId = 20 }, @{ nodeRoleId = 11; policyId = 21 })
+		Set-NinjaOneOrganisationPolicies -organisationId 4 -policyAssignments $assignments -Confirm:$false
+		Assert-MockCalled -CommandName New-NinjaOnePUTRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/organization/4/policies'
+		}
+	}
+
+	It 'delegates PUT failures to New-NinjaOneError for Single parameter set' {
+		Mock -CommandName New-NinjaOnePUTRequest -ModuleName $ModuleName -MockWith { throw 'policies-put-failed' }
+		{ Set-NinjaOneOrganisationPolicies -organisationId 4 -nodeRoleId 10 -policyId 20 -Confirm:$false } | Should -Throw '*policies-put-failed*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
 Get-Module -Name $ModuleName | Remove-Module -Force -ErrorAction SilentlyContinue
 Import-Module $ModulePath -Force
 

--- a/Tests/NinjaOne.Public.Tests.ps1
+++ b/Tests/NinjaOne.Public.Tests.ps1
@@ -213,6 +213,60 @@ Describe 'Public Query Functions - Contract Matrix' {
 			ExpectedRemovedQueryKey = 'timeStampUnixEpoch'
 			ExpectedError = 'No RAID drives found.'
 		}
+		[pscustomobject]@{
+			Name = 'Get-NinjaOneOSPatches endpoint and timestamp unix promotion'
+			InvokeSuccess = { Get-NinjaOneOSPatches }
+			InvokeQuery = { Get-NinjaOneOSPatches -timeStampUnixEpoch 1619712000 }
+			ExpectedResource = 'v2/queries/os-patches'
+			ExpectedQueryKey = 'timeStamp'
+			ExpectedRemovedQueryKey = 'timeStampUnixEpoch'
+			ExpectedError = 'No OS patches found.'
+		}
+		[pscustomobject]@{
+			Name = 'Get-NinjaOneOSPatchInstalls endpoint and installedBefore unix promotion'
+			InvokeSuccess = { Get-NinjaOneOSPatchInstalls }
+			InvokeQuery = { Get-NinjaOneOSPatchInstalls -installedBeforeUnixEpoch 1619712000 }
+			ExpectedResource = 'v2/queries/os-patch-installs'
+			ExpectedQueryKey = 'installedBefore'
+			ExpectedRemovedQueryKey = 'installedBeforeUnixEpoch'
+			ExpectedError = 'No OS patch installs found.'
+		}
+		[pscustomobject]@{
+			Name = 'Get-NinjaOnePolicyOverrides endpoint and deviceFilter query'
+			InvokeSuccess = { Get-NinjaOnePolicyOverrides }
+			InvokeQuery = { Get-NinjaOnePolicyOverrides -deviceFilter 'org = 1' }
+			ExpectedResource = 'v2/queries/policy-overrides'
+			ExpectedQueryKey = 'deviceFilter'
+			ExpectedRemovedQueryKey = $null
+			ExpectedError = 'No policy overrides found.'
+		}
+		[pscustomobject]@{
+			Name = 'Get-NinjaOneSoftwarePatches endpoint and timestamp unix promotion'
+			InvokeSuccess = { Get-NinjaOneSoftwarePatches }
+			InvokeQuery = { Get-NinjaOneSoftwarePatches -timeStampUnixEpoch 1619712000 }
+			ExpectedResource = 'v2/queries/software-patches'
+			ExpectedQueryKey = 'timeStamp'
+			ExpectedRemovedQueryKey = 'timeStampUnixEpoch'
+			ExpectedError = 'No software patches found.'
+		}
+		[pscustomobject]@{
+			Name = 'Get-NinjaOneSoftwarePatchInstalls endpoint and installedAfter unix promotion'
+			InvokeSuccess = { Get-NinjaOneSoftwarePatchInstalls }
+			InvokeQuery = { Get-NinjaOneSoftwarePatchInstalls -installedAfterUnixEpoch 1619712000 }
+			ExpectedResource = 'v2/queries/software-patch-installs'
+			ExpectedQueryKey = 'installedAfter'
+			ExpectedRemovedQueryKey = 'installedAfterUnixEpoch'
+			ExpectedError = 'No software patch installs found.'
+		}
+		[pscustomobject]@{
+			Name = 'Get-NinjaOneWindowsServices endpoint and state query'
+			InvokeSuccess = { Get-NinjaOneWindowsServices }
+			InvokeQuery = { Get-NinjaOneWindowsServices -state 'RUNNING' }
+			ExpectedResource = 'v2/queries/windows-services'
+			ExpectedQueryKey = 'state'
+			ExpectedRemovedQueryKey = $null
+			ExpectedError = 'No windows services found.'
+		}
 	)
 
 	It 'returns data and calls expected resource for <Name>' -ForEach $ContractCases {
@@ -244,6 +298,15 @@ Describe 'Public Query Functions - Contract Matrix' {
 		}
 
 		{ & $PSItem.InvokeSuccess } | Should -Throw ('*{0}*' -f $PSItem.ExpectedError)
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+
+	It 'delegates upstream API exceptions for <Name>' -ForEach $ContractCases {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			throw [System.InvalidOperationException]::new('upstream-api-failure')
+		}
+
+		{ & $PSItem.InvokeSuccess } | Should -Throw '*upstream-api-failure*'
 		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
 	}
 }

--- a/Tests/NinjaOne.Public.Tests.ps1
+++ b/Tests/NinjaOne.Public.Tests.ps1
@@ -214,6 +214,74 @@ Describe 'Get-NinjaOneActivities' {
 	}
 }
 
+Describe 'Get-NinjaOneUsers' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith {
+			@{}
+		}
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@(
+				[pscustomobject]@{
+					id = 1
+					name = 'Test User'
+				}
+			)
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'uses the default users endpoint when organisationId is not supplied' {
+		$module = Get-Module -Name $ModuleName
+		$result = & $module {
+			Get-NinjaOneUsers -includeRoles
+		}
+
+		@($result).Count | Should -Be 1
+		$result[0].id | Should -Be 1
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter { $Resource -eq 'v2/users' }
+	}
+
+	It 'uses the organisation users endpoint when organisationId is supplied' {
+		$module = Get-Module -Name $ModuleName
+		$result = & $module {
+			Get-NinjaOneUsers -organisationId 7 -userType END_USER
+		}
+
+		@($result).Count | Should -Be 1
+		$result[0].name | Should -Be 'Test User'
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter { $Resource -eq 'v2/organization/7/end-users' }
+	}
+
+	It 'delegates no-result default-path failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			$null
+		}
+
+		$module = Get-Module -Name $ModuleName
+		& $module {
+			{ Get-NinjaOneUsers } | Should -Throw '*No users found*'
+		}
+
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+
+	It 'delegates no-result organisation-path failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			$null
+		}
+
+		$module = Get-Module -Name $ModuleName
+		& $module {
+			{ Get-NinjaOneUsers -organisationId 12 -userType END_USER } | Should -Throw '*No users found for organisation 12*'
+		}
+
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
 # ============================================================================
 # COMPREHENSIVE PUBLIC QUERY TEST SUITE SUMMARY
 # ============================================================================

--- a/Tests/NinjaOne.Public.Tests.ps1
+++ b/Tests/NinjaOne.Public.Tests.ps1
@@ -776,3 +776,230 @@ Describe 'Get-NinjaOneSoftwareInventory' {
 		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
 	}
 }
+
+Describe 'Get-NinjaOneOrganisations' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith {
+			[System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+		}
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@([pscustomobject]@{ id = 1; name = 'Contoso' })
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'uses the organisations endpoint by default' {
+		$null = Get-NinjaOneOrganisations
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/organizations'
+		}
+	}
+
+	It 'uses the detailed organisations endpoint when -detailed is supplied' {
+		$null = Get-NinjaOneOrganisations -detailed
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/organizations-detailed'
+		}
+		Assert-MockCalled -CommandName New-NinjaOneQuery -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			-not $Parameters.ContainsKey('detailed')
+		}
+	}
+
+	It 'uses the single-organisation endpoint when organisationId is supplied' {
+		$null = Get-NinjaOneOrganisations -organisationId 21
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/organization/21'
+		}
+	}
+
+	It 'normalizes upstream request failures to a no-organisations error via New-NinjaOneError' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			throw 'request-failed'
+		}
+
+		{ Get-NinjaOneOrganisations } | Should -Throw '*No organisations found*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Get-NinjaOneLocations' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith {
+			[System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+		}
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@([pscustomobject]@{ id = 101; name = 'London' })
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'uses the global locations endpoint when organisationId is not supplied' {
+		$null = Get-NinjaOneLocations
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/locations'
+		}
+	}
+
+	It 'uses the organisation locations endpoint when organisationId is supplied' {
+		$null = Get-NinjaOneLocations -organisationId 12
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/organization/12/locations'
+		}
+	}
+
+	It 'delegates no-result failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { $null }
+
+		{ Get-NinjaOneLocations -organisationId 12 } | Should -Throw '*No locations found for organisation 12*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Get-NinjaOneDevices' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith {
+			[System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+		}
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@([pscustomobject]@{ id = 7; systemName = 'WS-07' })
+		}
+		Mock -CommandName Get-NinjaOneOrganisations -ModuleName $ModuleName -MockWith {
+			[pscustomobject]@{ id = 22 }
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'uses the devices endpoint by default' {
+		$null = Get-NinjaOneDevices
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/devices'
+		}
+	}
+
+	It 'uses the detailed devices endpoint when -detailed is supplied' {
+		$null = Get-NinjaOneDevices -detailed
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/devices-detailed'
+		}
+	}
+
+	It 'uses the single device endpoint when deviceId is supplied' {
+		$null = Get-NinjaOneDevices -deviceId 7
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/device/7'
+		}
+	}
+
+	It 'uses the organisation devices endpoint when organisationId is supplied and organisation exists' {
+		$null = Get-NinjaOneDevices -organisationId 22
+
+		Assert-MockCalled -CommandName Get-NinjaOneOrganisations -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$organisationId -eq 22
+		}
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/organization/22/devices'
+		}
+	}
+
+	It 'passes parseDateTime through to the GET request' {
+		$null = Get-NinjaOneDevices -parseDateTime
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$ParseDateTime -eq $true
+		}
+	}
+
+	It 'normalizes upstream request failures to a not-found device error via New-NinjaOneError' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			throw 'request-failed'
+		}
+
+		{ Get-NinjaOneDevices -deviceId 7 } | Should -Throw '*Device with id 7 not found*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Get-NinjaOneGroups' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith {
+			[System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+		}
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@([pscustomobject]@{ id = 1; name = 'Servers' })
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'uses the groups endpoint' {
+		$null = Get-NinjaOneGroups
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/groups'
+		}
+	}
+
+	It 'passes languageTag as a query parameter' {
+		$null = Get-NinjaOneGroups -languageTag 'en-GB'
+
+		Assert-MockCalled -CommandName New-NinjaOneQuery -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Parameters.ContainsKey('languageTag')
+		}
+	}
+
+	It 'delegates no-result failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { $null }
+
+		{ Get-NinjaOneGroups } | Should -Throw '*No groups found*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Get-NinjaOnePolicies' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith {
+			[System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+		}
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@([pscustomobject]@{ id = 1; name = 'Workstation Policy' })
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'uses the policies endpoint' {
+		$null = Get-NinjaOnePolicies
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/policies'
+		}
+	}
+
+	It 'delegates no-result failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { $null }
+
+		{ Get-NinjaOnePolicies } | Should -Throw '*No policies found*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}

--- a/Tests/NinjaOne.Public.Tests.ps1
+++ b/Tests/NinjaOne.Public.Tests.ps1
@@ -1107,6 +1107,165 @@ Describe 'Set-NinjaOneCustomField' {
 	}
 }
 
+Describe 'Invoke-NinjaOneDeviceScript' {
+	BeforeEach {
+		Mock -CommandName Get-NinjaOneDevice -ModuleName $ModuleName -MockWith {
+			[pscustomobject]@{ id = 44; SystemName = 'WS-44' }
+		}
+		Mock -CommandName Get-NinjaOneDeviceScriptingOptions -ModuleName $ModuleName -MockWith {
+			@(
+				[pscustomobject]@{ id = 12; uid = [guid]'11111111-1111-1111-1111-111111111111'; type = 'SCRIPT'; Name = 'Collect Logs' },
+				[pscustomobject]@{ id = 99; uid = [guid]'22222222-2222-2222-2222-222222222222'; type = 'ACTION'; Name = 'Restart Service' }
+			)
+		}
+		Mock -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -MockWith { 204 }
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'posts script run requests to v2/device/{id}/script/run with script id' {
+		$null = Invoke-NinjaOneDeviceScript -deviceId 44 -type 'SCRIPT' -scriptId 12 -runAs 'system' -parameters 'mode=quick'
+
+		Assert-MockCalled -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/device/44/script/run' -and
+			$Body.type -eq 'SCRIPT' -and
+			$Body.id -eq 12 -and
+			$Body.runAs -eq 'system' -and
+			$Body.parameters -eq 'mode=quick'
+		}
+	}
+
+	It 'posts action run requests with action uid' {
+		$actionUId = [guid]'22222222-2222-2222-2222-222222222222'
+		$null = Invoke-NinjaOneDeviceScript -deviceId 44 -type 'ACTION' -actionUId $actionUId -runAs 'loggedonuser'
+
+		Assert-MockCalled -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/device/44/script/run' -and
+			$Body.type -eq 'ACTION' -and
+			$Body.uid -eq $actionUId -and
+			$Body.runAs -eq 'loggedonuser' -and
+			-not $Body.ContainsKey('id')
+		}
+	}
+
+	It 'returns 204 when -show is supplied' {
+		$result = Invoke-NinjaOneDeviceScript -deviceId 44 -type 'SCRIPT' -scriptId 12 -runAs 'system' -show
+
+		$result | Should -Be 204
+	}
+
+	It 'delegates not-found script failures to New-NinjaOneError' {
+		Mock -CommandName Get-NinjaOneDeviceScriptingOptions -ModuleName $ModuleName -MockWith {
+			@([pscustomobject]@{ id = 1; type = 'SCRIPT'; Name = 'Different script' })
+		}
+
+		{ Invoke-NinjaOneDeviceScript -deviceId 44 -type 'SCRIPT' -scriptId 12 -runAs 'system' } | Should -Throw '*Script with id 12 not found*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'New-NinjaOneInstaller' {
+	BeforeEach {
+		Mock -CommandName Get-NinjaOneOrganisations -ModuleName $ModuleName -MockWith {
+			@([pscustomobject]@{ id = 7; name = 'Contoso' })
+		}
+		Mock -CommandName Get-NinjaOneLocations -ModuleName $ModuleName -MockWith {
+			@([pscustomobject]@{ id = 17; name = 'HQ' })
+		}
+		Mock -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -MockWith {
+			[pscustomobject]@{ url = 'https://example.test/installer' }
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'creates an installer from individual parameters and returns the URL' {
+		$result = New-NinjaOneInstaller -organisationId 7 -locationId 17 -installerType 'WINDOWS_MSI' -Confirm:$false
+
+		$result | Should -Be 'https://example.test/installer'
+		Assert-MockCalled -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/organization/generate-installer' -and
+			$Body.organization_id -eq 7 -and
+			$Body.location_id -eq 17 -and
+			$Body.installer_type -eq 'WINDOWS_MSI'
+		}
+	}
+
+	It 'creates an installer from body parameter set and returns the URL' {
+		$installer = @{
+			organizationId = 7
+			locationId = 17
+			installer_type = 'WINDOWS_MSI'
+			content = @{ nodeRoleId = 'auto' }
+		}
+
+		$result = New-NinjaOneInstaller -installer $installer -Confirm:$false
+
+		$result | Should -Be 'https://example.test/installer'
+		Assert-MockCalled -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/organization/generate-installer'
+		}
+	}
+
+	It 'delegates validation failures to New-NinjaOneError when organisation/location do not exist' {
+		Mock -CommandName Get-NinjaOneLocations -ModuleName $ModuleName -MockWith {
+			@([pscustomobject]@{ id = 99; name = 'Other' })
+		}
+
+		{ New-NinjaOneInstaller -organisationId 7 -locationId 17 -installerType 'WINDOWS_MSI' -Confirm:$false } | Should -Throw '*does not exist*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+
+	It 'delegates POST failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -MockWith { throw 'installer-create-failed' }
+
+		{ New-NinjaOneInstaller -organisationId 7 -locationId 17 -installerType 'WINDOWS_MSI' -Confirm:$false } | Should -Throw '*installer-create-failed*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Get-NinjaOneSoftwarePatches' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith {
+			[System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+		}
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@([pscustomobject]@{ id = 1; status = 'APPROVED' })
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'calls the software patches query endpoint' {
+		$null = Get-NinjaOneSoftwarePatches
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/queries/software-patches'
+		}
+	}
+
+	It 'promotes timeStampUnixEpoch to timeStamp in query parameters' {
+		$null = Get-NinjaOneSoftwarePatches -timeStampUnixEpoch 1619712000
+
+		Assert-MockCalled -CommandName New-NinjaOneQuery -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Parameters.ContainsKey('timeStamp') -and -not $Parameters.ContainsKey('timeStampUnixEpoch')
+		}
+	}
+
+	It 'delegates no-result failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { $null }
+
+		{ Get-NinjaOneSoftwarePatches } | Should -Throw '*No software patches found*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
 Get-Module -Name $ModuleName | Remove-Module -Force -ErrorAction SilentlyContinue
 Import-Module $ModulePath -Force
 

--- a/Tests/NinjaOne.Public.Tests.ps1
+++ b/Tests/NinjaOne.Public.Tests.ps1
@@ -1704,6 +1704,14 @@ Describe 'New-NinjaOnePolicy' {
 		{ New-NinjaOnePolicy -mode 'COPY' -policy $policy } | Should -Throw '*template policy id*'
 	}
 
+	It 'allows COPY mode when templatePolicyId is provided' {
+		$policy = [PSCustomObject]@{ name = 'CopyPolicy'; nodeClass = 'WINDOWS_SERVER' }
+
+		New-NinjaOnePolicy -mode 'COPY' -policy $policy -templatePolicyId 10
+
+		Should -Invoke -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -Times 1 -Exactly
+	}
+
 	It 'skips POST when WhatIf is used' {
 		$policy = [PSCustomObject]@{ name = 'TestPolicy'; nodeClass = 'WINDOWS_SERVER'; enabled = $true }
 		New-NinjaOnePolicy -mode 'NEW' -policy $policy -WhatIf
@@ -1798,6 +1806,280 @@ Describe 'New-NinjaOneWindowsEventPolicyCondition' {
 		$condition = [PSCustomObject]@{ displayName = 'TestCondition'; enabled = $true }
 
 		{ New-NinjaOneWindowsEventPolicyCondition -policyId 15 -windowsEventPolicyCondition $condition } | Should -Throw
+	}
+}
+
+Describe 'Reset-NinjaOneAlert' {
+	BeforeAll {
+		Mock -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -MockWith { 204 }
+		Mock -CommandName New-NinjaOneDELETERequest -ModuleName $ModuleName -MockWith { 204 }
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith { param($ErrorRecord); throw $ErrorRecord.Exception }
+	}
+
+	It 'uses POST reset endpoint when activityData is provided' {
+		$activityData = [PSCustomObject]@{ reason = 'manual reset' }
+
+		Reset-NinjaOneAlert -uid '15' -activityData $activityData
+
+		Should -Invoke -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -ParameterFilter {
+			$Resource -eq 'v2/alert/15/reset' -and
+			$Body.reason -eq 'manual reset'
+		} -Times 1 -Exactly
+	}
+
+	It 'uses DELETE endpoint when activityData is not provided' {
+		Reset-NinjaOneAlert -uid '20'
+
+		Should -Invoke -CommandName New-NinjaOneDELETERequest -ModuleName $ModuleName -ParameterFilter {
+			$Resource -eq 'v2/alert/20'
+		} -Times 1 -Exactly
+	}
+
+	It 'skips POST when WhatIf is used' {
+		$activityData = [PSCustomObject]@{ reason = 'manual reset' }
+
+		Reset-NinjaOneAlert -uid '30' -activityData $activityData -WhatIf
+
+		Should -Invoke -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -Times 0 -Exactly
+	}
+
+	It 'skips DELETE when WhatIf is used' {
+		Reset-NinjaOneAlert -uid '31' -WhatIf
+
+		Should -Invoke -CommandName New-NinjaOneDELETERequest -ModuleName $ModuleName -Times 0 -Exactly
+	}
+
+	It 'surfaces API errors through New-NinjaOneError' {
+		Mock -CommandName New-NinjaOneDELETERequest -ModuleName $ModuleName -MockWith { throw 'API failure' }
+
+		{ Reset-NinjaOneAlert -uid '99' } | Should -Throw
+	}
+}
+
+Describe 'Get-NinjaOneTicketLogEntries' {
+	BeforeAll {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith { [System.Web.HttpUtility]::ParseQueryString([String]::Empty) }
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@([PSCustomObject]@{ id = 1; type = 'DESCRIPTION'; message = 'entry' })
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith { param($ErrorRecord); throw $ErrorRecord.Exception }
+	}
+
+	It 'calls the expected ticket log endpoint' {
+		Get-NinjaOneTicketLogEntries -ticketId '7'
+
+		Should -Invoke -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -ParameterFilter {
+			$Resource -eq 'v2/ticketing/ticket/7/log-entry'
+		} -Times 1 -Exactly
+	}
+
+	It 'passes ParseDateTime when switch is set' {
+		Get-NinjaOneTicketLogEntries -ticketId '8' -parseDateTime
+
+		Should -Invoke -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -ParameterFilter {
+			$Resource -eq 'v2/ticketing/ticket/8/log-entry' -and
+			$ParseDateTime
+		} -Times 1 -Exactly
+	}
+
+	It 'returns ticket log results' {
+		$result = Get-NinjaOneTicketLogEntries -ticketId '9'
+
+		$result | Should -Not -BeNullOrEmpty
+		$result[0].type | Should -Be 'DESCRIPTION'
+	}
+
+	It 'throws specific message when no results and type is provided' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { $null }
+
+		{ Get-NinjaOneTicketLogEntries -ticketId '10' -type 'DESCRIPTION' } | Should -Throw '*with type DESCRIPTION*'
+	}
+
+	It 'throws specific message when no results and type is not provided' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { $null }
+
+		{ Get-NinjaOneTicketLogEntries -ticketId '11' } | Should -Throw '*No ticket log entries found for ticket 11*'
+	}
+}
+
+Describe 'New-NinjaOneDocumentTemplateFieldObject' {
+	It 'creates a Field object with required properties and type name' {
+		$result = New-NinjaOneDocumentTemplateFieldObject -label 'Field A' -Name 'fieldA' -type 'TEXT'
+
+		$result.fieldLabel | Should -Be 'Field A'
+		$result.fieldName | Should -Be 'fieldA'
+		$result.fieldType | Should -Be 'TEXT'
+		$result.PSObject.TypeNames[0] | Should -Be 'DocumentTemplateField'
+	}
+
+	It 'adds optional Field properties when specified' {
+		$options = @('Option1', 'Option2')
+		$result = New-NinjaOneDocumentTemplateFieldObject -label 'Field B' -Name 'fieldB' -description 'desc' -type 'DROPDOWN' -defaultValue 'Option1' -options $options
+
+		$result.fieldDescription | Should -Be 'desc'
+		$result.fieldDefaultValue | Should -Be 'Option1'
+		$result.fieldContent.Count | Should -Be 2
+	}
+
+	It 'creates a UI element object with required properties and type name' {
+		$result = New-NinjaOneDocumentTemplateFieldObject -elementName 'Heading' -elementType 'TITLE' -elementValue 'Welcome'
+
+		$result.uiElementName | Should -Be 'Heading'
+		$result.uiElementType | Should -Be 'TITLE'
+		$result.uiElementValue | Should -Be 'Welcome'
+		$result.PSObject.TypeNames[0] | Should -Be 'DocumentTemplateField'
+	}
+
+	It 'omits UI element value when not provided' {
+		$result = New-NinjaOneDocumentTemplateFieldObject -elementName 'Rule' -elementType 'SEPARATOR'
+
+		$result.PSObject.Properties.Name -contains 'uiElementValue' | Should -BeFalse
+	}
+}
+
+Describe 'Get-NinjaOneTicketForms' {
+	BeforeAll {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith { [System.Web.HttpUtility]::ParseQueryString([String]::Empty) }
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@([PSCustomObject]@{ id = 1; name = 'Default Form' })
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith { param($ErrorRecord); throw $ErrorRecord.Exception }
+	}
+
+	It 'calls list endpoint when ticketFormId is not provided' {
+		Get-NinjaOneTicketForms
+
+		Should -Invoke -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -ParameterFilter {
+			$Resource -eq '/v2/ticketing/ticket-form'
+		} -Times 1 -Exactly
+	}
+
+	It 'calls single-item endpoint when ticketFormId is provided' {
+		Get-NinjaOneTicketForms -ticketFormId 8
+
+		Should -Invoke -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -ParameterFilter {
+			$Resource -eq '/v2/ticketing/ticket-form/8'
+		} -Times 1 -Exactly
+	}
+
+	It 'returns ticket forms' {
+		$result = Get-NinjaOneTicketForms
+
+		$result[0].name | Should -Be 'Default Form'
+	}
+
+	It 'throws when no ticket forms are found' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { $null }
+
+		{ Get-NinjaOneTicketForms } | Should -Throw '*No ticket forms found*'
+	}
+}
+
+Describe 'Get-NinjaOneTicketingContacts' {
+	BeforeAll {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith { [System.Web.HttpUtility]::ParseQueryString([String]::Empty) }
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@([PSCustomObject]@{ id = 1; name = 'Contact 1' })
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith { param($ErrorRecord); throw $ErrorRecord.Exception }
+	}
+
+	It 'calls the expected ticketing contacts endpoint' {
+		Get-NinjaOneTicketingContacts
+
+		Should -Invoke -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -ParameterFilter {
+			$Resource -eq 'v2/ticketing/contact/contacts'
+		} -Times 1 -Exactly
+	}
+
+	It 'returns contacts when present' {
+		$result = Get-NinjaOneTicketingContacts
+
+		$result | Should -Not -BeNullOrEmpty
+		$result[0].name | Should -Be 'Contact 1'
+	}
+
+	It 'throws when no contacts are found' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { $null }
+
+		{ Get-NinjaOneTicketingContacts } | Should -Throw '*No ticketing contacts found*'
+	}
+}
+
+Describe 'New-NinjaOneEntityRelation' {
+	BeforeAll {
+		Mock -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -MockWith {
+			[PSCustomObject]@{ id = 100; relEntityType = 'NODE'; relEntityId = 50 }
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith { param($ErrorRecord); throw $ErrorRecord.Exception }
+	}
+
+	It 'posts to the expected relation endpoint' {
+		New-NinjaOneEntityRelation -entityType 'ORGANIZATION' -entityId 1 -relatedEntityType 'NODE' -relatedEntityId 50
+
+		Should -Invoke -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -ParameterFilter {
+			$Resource -eq 'v2/related-items/entity/ORGANIZATION/1/relation' -and
+			$Body.relEntityType -eq 'NODE' -and
+			$Body.relEntityId -eq 50
+		} -Times 1 -Exactly
+	}
+
+	It 'returns result when -show is used' {
+		$result = New-NinjaOneEntityRelation -entityType 'ORGANIZATION' -entityId 1 -relatedEntityType 'NODE' -relatedEntityId 50 -show
+
+		$result.relEntityId | Should -Be 50
+	}
+
+	It 'skips POST when WhatIf is used' {
+		New-NinjaOneEntityRelation -entityType 'ORGANIZATION' -entityId 1 -relatedEntityType 'NODE' -relatedEntityId 50 -WhatIf
+
+		Should -Invoke -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -Times 0 -Exactly
+	}
+
+	It 'surfaces API errors through New-NinjaOneError' {
+		Mock -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -MockWith { throw 'API failure' }
+
+		{ New-NinjaOneEntityRelation -entityType 'ORGANIZATION' -entityId 1 -relatedEntityType 'NODE' -relatedEntityId 50 } | Should -Throw
+	}
+}
+
+Describe 'New-NinjaOneEntityRelations' {
+	BeforeAll {
+		Mock -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -MockWith {
+			@([PSCustomObject]@{ relEntityType = 'NODE'; relEntityId = 51 })
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith { param($ErrorRecord); throw $ErrorRecord.Exception }
+	}
+
+	It 'posts relation array to the expected endpoint' {
+		$relations = @([PSCustomObject]@{ relEntityType = 'NODE'; relEntityId = 51 })
+		New-NinjaOneEntityRelations -entityType 'ORGANIZATION' -entityId 1 -entityRelations $relations
+
+		Should -Invoke -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -ParameterFilter {
+			$Resource -eq 'v2/related-items/entity/ORGANIZATION/1/relations' -and
+			$Body[0].relEntityId -eq 51
+		} -Times 1 -Exactly
+	}
+
+	It 'returns created relations when -show is used' {
+		$relations = @([PSCustomObject]@{ relEntityType = 'NODE'; relEntityId = 51 })
+		$result = New-NinjaOneEntityRelations -entityType 'ORGANIZATION' -entityId 1 -entityRelations $relations -show
+
+		$result[0].relEntityId | Should -Be 51
+	}
+
+	It 'skips POST when WhatIf is used' {
+		$relations = @([PSCustomObject]@{ relEntityType = 'NODE'; relEntityId = 51 })
+		New-NinjaOneEntityRelations -entityType 'ORGANIZATION' -entityId 1 -entityRelations $relations -WhatIf
+
+		Should -Invoke -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -Times 0 -Exactly
+	}
+
+	It 'surfaces API errors through New-NinjaOneError' {
+		Mock -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -MockWith { throw 'API failure' }
+		$relations = @([PSCustomObject]@{ relEntityType = 'NODE'; relEntityId = 51 })
+
+		{ New-NinjaOneEntityRelations -entityType 'ORGANIZATION' -entityId 1 -entityRelations $relations } | Should -Throw
 	}
 }
 

--- a/Tests/NinjaOne.Public.Tests.ps1
+++ b/Tests/NinjaOne.Public.Tests.ps1
@@ -59,6 +59,105 @@ Describe 'Public Query Functions - Existence Tests' {
 	}
 }
 
+Describe 'Public Query Functions - Contract Matrix' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith {
+			[System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+		}
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@(
+				[pscustomobject]@{
+					id = 1
+				}
+			)
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	$ContractCases = @(
+		[pscustomobject]@{
+			Name = 'Get-NinjaOneCustomFields default endpoint and fields query'
+			InvokeSuccess = { Get-NinjaOneCustomFields }
+			InvokeQuery = { Get-NinjaOneCustomFields -fields @('hasBatteries', 'autopilotHwid') }
+			ExpectedResource = 'v2/queries/custom-fields'
+			ExpectedQueryKey = 'fields'
+			ExpectedRemovedQueryKey = $null
+			ExpectedError = 'No custom fields found.'
+		}
+		[pscustomobject]@{
+			Name = 'Get-NinjaOneCustomFields scoped detailed endpoint and scopes query'
+			InvokeSuccess = { Get-NinjaOneCustomFields -scopes 'NODE' -detailed }
+			InvokeQuery = { Get-NinjaOneCustomFields -scopes 'NODE' -detailed }
+			ExpectedResource = 'v2/queries/scoped-custom-fields-detailed'
+			ExpectedQueryKey = 'scopes'
+			ExpectedRemovedQueryKey = 'detailed'
+			ExpectedError = 'No custom fields found.'
+		}
+		[pscustomobject]@{
+			Name = 'Get-NinjaOneAntivirusStatus endpoint and timestamp unix promotion'
+			InvokeSuccess = { Get-NinjaOneAntivirusStatus }
+			InvokeQuery = { Get-NinjaOneAntivirusStatus -timeStampUnixEpoch 1619712000 }
+			ExpectedResource = 'v2/queries/antivirus-status'
+			ExpectedQueryKey = 'timeStamp'
+			ExpectedRemovedQueryKey = 'timeStampUnixEpoch'
+			ExpectedError = 'No antivirus status found.'
+		}
+		[pscustomobject]@{
+			Name = 'Get-NinjaOneAntivirusThreats endpoint and timestamp unix promotion'
+			InvokeSuccess = { Get-NinjaOneAntivirusThreats }
+			InvokeQuery = { Get-NinjaOneAntivirusThreats -timeStampUnixEpoch 1619712000 }
+			ExpectedResource = 'v2/queries/antivirus-threats'
+			ExpectedQueryKey = 'timeStamp'
+			ExpectedRemovedQueryKey = 'timeStampUnixEpoch'
+			ExpectedError = 'No antivirus threats found.'
+		}
+		[pscustomobject]@{
+			Name = 'Get-NinjaOneDeviceBackupUsage endpoint and includeDeleted query'
+			InvokeSuccess = { Get-NinjaOneDeviceBackupUsage }
+			InvokeQuery = { Get-NinjaOneDeviceBackupUsage -includeDeleted }
+			ExpectedResource = 'v2/queries/backup/usage'
+			ExpectedQueryKey = 'includeDeleted'
+			ExpectedRemovedQueryKey = $null
+			ExpectedError = 'No backup usage found.'
+		}
+	)
+
+	It 'returns data and calls expected resource for <Name>' -ForEach $ContractCases {
+		$result = & $PSItem.InvokeSuccess
+
+		@($result).Count | Should -Be 1
+		$result[0].id | Should -Be 1
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq $PSItem.ExpectedResource
+		}
+	}
+
+	It 'builds expected query keys for <Name>' -ForEach $ContractCases {
+		$null = & $PSItem.InvokeQuery
+
+		Assert-MockCalled -CommandName New-NinjaOneQuery -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$HasExpected = $Parameters.ContainsKey($PSItem.ExpectedQueryKey)
+			if ([string]::IsNullOrWhiteSpace($PSItem.ExpectedRemovedQueryKey)) {
+				return $HasExpected
+			}
+
+			return $HasExpected -and (-not $Parameters.ContainsKey($PSItem.ExpectedRemovedQueryKey))
+		}
+	}
+
+	It 'delegates no-result errors for <Name>' -ForEach $ContractCases {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			$null
+		}
+
+		{ & $PSItem.InvokeSuccess } | Should -Throw ('*{0}*' -f $PSItem.ExpectedError)
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
 Describe 'New-NinjaOneTicketComment' {
 	It 'wraps a simple comment object in a multipart envelope' {
 		$module = Get-Module -Name 'NinjaOne' | Select-Object -First 1

--- a/Tests/NinjaOne.Public.Tests.ps1
+++ b/Tests/NinjaOne.Public.Tests.ps1
@@ -258,6 +258,164 @@ Describe 'Set-NinjaOneOrganisationPolicies' {
 	}
 }
 
+Describe 'Get-NinjaOneDeviceDisks' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith {
+			[System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+		}
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@([pscustomobject]@{ name = 'Disk0' })
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'calls the device disks endpoint for the supplied id' {
+		$null = Get-NinjaOneDeviceDisks -deviceId 88
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/device/88/disks'
+		}
+	}
+
+	It 'delegates GET failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { throw 'device-disks-failed' }
+
+		{ Get-NinjaOneDeviceDisks -deviceId 88 } | Should -Throw '*device-disks-failed*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Get-NinjaOneDeviceNetworkInterfaces' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith {
+			[System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+		}
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@([pscustomobject]@{ name = 'Ethernet0' })
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'calls the device network interfaces endpoint for the supplied id' {
+		$null = Get-NinjaOneDeviceNetworkInterfaces -deviceId 55
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/device/55/network-interfaces'
+		}
+	}
+
+	It 'delegates GET failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { throw 'device-nics-failed' }
+
+		{ Get-NinjaOneDeviceNetworkInterfaces -deviceId 55 } | Should -Throw '*device-nics-failed*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Get-NinjaOneDeviceVolumes' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith {
+			[System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+		}
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@([pscustomobject]@{ name = 'C:' })
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'calls the device volumes endpoint for the supplied id' {
+		$null = Get-NinjaOneDeviceVolumes -deviceId 101
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/device/101/volumes'
+		}
+	}
+
+	It 'passes include as a query parameter' {
+		$null = Get-NinjaOneDeviceVolumes -deviceId 101 -include 'bl'
+
+		Assert-MockCalled -CommandName New-NinjaOneQuery -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Parameters.ContainsKey('include')
+		}
+	}
+
+	It 'delegates GET failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { throw 'device-volumes-failed' }
+
+		{ Get-NinjaOneDeviceVolumes -deviceId 101 } | Should -Throw '*device-volumes-failed*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Get-NinjaOneTicketAttributes' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith {
+			[System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+		}
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@([pscustomobject]@{ id = 1; name = 'Priority' })
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'calls the ticket attributes endpoint' {
+		$null = Get-NinjaOneTicketAttributes
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/ticketing/attributes'
+		}
+	}
+
+	It 'delegates no-result failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { $null }
+
+		{ Get-NinjaOneTicketAttributes } | Should -Throw '*No ticket attributes found*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Get-NinjaOneTicketBoards' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith {
+			[System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+		}
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@([pscustomobject]@{ id = 10; name = 'Default Board' })
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'calls the ticket boards endpoint' {
+		$null = Get-NinjaOneTicketBoards
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/ticketing/trigger/boards'
+		}
+	}
+
+	It 'delegates no-result failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { $null }
+
+		{ Get-NinjaOneTicketBoards } | Should -Throw '*No boards found*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
 Get-Module -Name $ModuleName | Remove-Module -Force -ErrorAction SilentlyContinue
 Import-Module $ModulePath -Force
 

--- a/Tests/NinjaOne.Public.Tests.ps1
+++ b/Tests/NinjaOne.Public.Tests.ps1
@@ -123,6 +123,96 @@ Describe 'Public Query Functions - Contract Matrix' {
 			ExpectedRemovedQueryKey = $null
 			ExpectedError = 'No backup usage found.'
 		}
+		[pscustomobject]@{
+			Name = 'Get-NinjaOneComputerSystems endpoint and timestamp unix promotion'
+			InvokeSuccess = { Get-NinjaOneComputerSystems }
+			InvokeQuery = { Get-NinjaOneComputerSystems -timeStampUnixEpoch 1619712000 }
+			ExpectedResource = 'v2/queries/computer-systems'
+			ExpectedQueryKey = 'timeStamp'
+			ExpectedRemovedQueryKey = 'timeStampUnixEpoch'
+			ExpectedError = 'No computer systems found.'
+		}
+		[pscustomobject]@{
+			Name = 'Get-NinjaOneDeviceHealth endpoint and health query'
+			InvokeSuccess = { Get-NinjaOneDeviceHealth }
+			InvokeQuery = { Get-NinjaOneDeviceHealth -health 'UNHEALTHY' }
+			ExpectedResource = 'v2/queries/device-health'
+			ExpectedQueryKey = 'health'
+			ExpectedRemovedQueryKey = $null
+			ExpectedError = 'No device health found.'
+		}
+		[pscustomobject]@{
+			Name = 'Get-NinjaOneDisks endpoint and timestamp unix promotion'
+			InvokeSuccess = { Get-NinjaOneDisks }
+			InvokeQuery = { Get-NinjaOneDisks -timeStampUnixEpoch 1619712000 }
+			ExpectedResource = 'v2/queries/disks'
+			ExpectedQueryKey = 'timeStamp'
+			ExpectedRemovedQueryKey = 'timeStampUnixEpoch'
+			ExpectedError = 'No disks found.'
+		}
+		[pscustomobject]@{
+			Name = 'Get-NinjaOneLoggedOnUsers endpoint and deviceFilter query'
+			InvokeSuccess = { Get-NinjaOneLoggedOnUsers }
+			InvokeQuery = { Get-NinjaOneLoggedOnUsers -deviceFilter 'org = 1' }
+			ExpectedResource = 'v2/queries/logged-on-users'
+			ExpectedQueryKey = 'deviceFilter'
+			ExpectedRemovedQueryKey = $null
+			ExpectedError = 'No logged on users found.'
+		}
+		[pscustomobject]@{
+			Name = 'Get-NinjaOneNetworkInterfaces endpoint and deviceFilter query'
+			InvokeSuccess = { Get-NinjaOneNetworkInterfaces }
+			InvokeQuery = { Get-NinjaOneNetworkInterfaces -deviceFilter 'org = 1' }
+			ExpectedResource = 'v2/queries/network-interfaces'
+			ExpectedQueryKey = 'deviceFilter'
+			ExpectedRemovedQueryKey = $null
+			ExpectedError = 'No network interfaces found.'
+		}
+		[pscustomobject]@{
+			Name = 'Get-NinjaOneOperatingSystems endpoint and timestamp unix promotion'
+			InvokeSuccess = { Get-NinjaOneOperatingSystems }
+			InvokeQuery = { Get-NinjaOneOperatingSystems -timeStampUnixEpoch 1619712000 }
+			ExpectedResource = 'v2/queries/operating-systems'
+			ExpectedQueryKey = 'timeStamp'
+			ExpectedRemovedQueryKey = 'timeStampUnixEpoch'
+			ExpectedError = 'No operating systems found.'
+		}
+		[pscustomobject]@{
+			Name = 'Get-NinjaOneProcessors endpoint and timestamp unix promotion'
+			InvokeSuccess = { Get-NinjaOneProcessors }
+			InvokeQuery = { Get-NinjaOneProcessors -timeStampUnixEpoch 1619712000 }
+			ExpectedResource = 'v2/queries/processors'
+			ExpectedQueryKey = 'timeStamp'
+			ExpectedRemovedQueryKey = 'timeStampUnixEpoch'
+			ExpectedError = 'No processors found.'
+		}
+		[pscustomobject]@{
+			Name = 'Get-NinjaOneVolumes endpoint and timestamp unix promotion'
+			InvokeSuccess = { Get-NinjaOneVolumes }
+			InvokeQuery = { Get-NinjaOneVolumes -timeStampUnixEpoch 1619712000 }
+			ExpectedResource = 'v2/queries/volumes'
+			ExpectedQueryKey = 'timeStamp'
+			ExpectedRemovedQueryKey = 'timeStampUnixEpoch'
+			ExpectedError = 'No volumes found.'
+		}
+		[pscustomobject]@{
+			Name = 'Get-NinjaOneRAIDControllers endpoint and timestamp unix promotion'
+			InvokeSuccess = { Get-NinjaOneRAIDControllers }
+			InvokeQuery = { Get-NinjaOneRAIDControllers -timeStampUnixEpoch 1619712000 }
+			ExpectedResource = 'v2/queries/raid-controllers'
+			ExpectedQueryKey = 'timeStamp'
+			ExpectedRemovedQueryKey = 'timeStampUnixEpoch'
+			ExpectedError = 'No RAID controllers found.'
+		}
+		[pscustomobject]@{
+			Name = 'Get-NinjaOneRAIDDrives endpoint and timestamp unix promotion'
+			InvokeSuccess = { Get-NinjaOneRAIDDrives }
+			InvokeQuery = { Get-NinjaOneRAIDDrives -timeStampUnixEpoch 1619712000 }
+			ExpectedResource = 'v2/queries/raid-drives'
+			ExpectedQueryKey = 'timeStamp'
+			ExpectedRemovedQueryKey = 'timeStampUnixEpoch'
+			ExpectedError = 'No RAID drives found.'
+		}
 	)
 
 	It 'returns data and calls expected resource for <Name>' -ForEach $ContractCases {

--- a/Tests/NinjaOne.Public.Tests.ps1
+++ b/Tests/NinjaOne.Public.Tests.ps1
@@ -1277,3 +1277,71 @@ Describe 'Get-NinjaOneSystemContacts' {
 		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
 	}
 }
+
+Describe 'New-NinjaOneContact' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -MockWith {
+			param($Resource, $Body)
+			[pscustomobject]@{
+				resource = $Resource
+				body = $Body
+			}
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'posts contact payload to the contacts endpoint when confirmed' {
+		$payload = @{ firstName = 'Jane'; lastName = 'Doe'; email = 'jane@example.com' }
+		$result = New-NinjaOneContact -contact $payload -Confirm:$false
+
+		$result.resource | Should -Be 'v2/contacts'
+		$result.body.firstName | Should -Be 'Jane'
+		Assert-MockCalled -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/contacts'
+		}
+	}
+
+	It 'delegates POST failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -MockWith { throw 'create-contact-failed' }
+
+		{ New-NinjaOneContact -contact @{ firstName = 'Jane' } -Confirm:$false } | Should -Throw '*create-contact-failed*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Set-NinjaOneContact' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOnePATCHRequest -ModuleName $ModuleName -MockWith {
+			param($Resource, $Body)
+			[pscustomobject]@{
+				resource = $Resource
+				body = $Body
+			}
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'patches contact payload to the specific contact endpoint when confirmed' {
+		$payload = @{ phone = '+3100000000' }
+		$result = Set-NinjaOneContact -id 123 -contact $payload -Confirm:$false
+
+		$result.resource | Should -Be 'v2/contact/123'
+		$result.body.phone | Should -Be '+3100000000'
+		Assert-MockCalled -CommandName New-NinjaOnePATCHRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/contact/123'
+		}
+	}
+
+	It 'delegates PATCH failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOnePATCHRequest -ModuleName $ModuleName -MockWith { throw 'update-contact-failed' }
+
+		{ Set-NinjaOneContact -id 123 -contact @{ phone = '+3100000000' } -Confirm:$false } | Should -Throw '*update-contact-failed*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}

--- a/Tests/NinjaOne.Public.Tests.ps1
+++ b/Tests/NinjaOne.Public.Tests.ps1
@@ -821,6 +821,153 @@ Describe 'Get-NinjaOneDeviceSoftwarePatchInstalls' {
 	}
 }
 
+Describe 'New-NinjaOneDocumentTemplate' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -MockWith {
+			[pscustomobject]@{ id = 500; name = 'Template A' }
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'calls POST v2/document-templates with the expected body' {
+		$field = [pscustomobject]@{
+			fieldName = 'Hostname'
+			fieldType = 'TEXT'
+		}
+		$field.PSObject.TypeNames.Insert(0, 'DocumentTemplateField')
+		$fields = @($field)
+
+		$null = New-NinjaOneDocumentTemplate -Name 'Template A' -fields $fields -description 'desc' -allowMultiple -mandatory -availableToAllTechnicians -allowedTechnicianRoles @(1, 2) -Confirm:$false
+
+		Assert-MockCalled -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/document-templates' -and
+			$Body.name -eq 'Template A' -and
+			$Body.description -eq 'desc' -and
+			$Body.allowMultiple -eq $true -and
+			$Body.mandatory -eq $true -and
+			$Body.availableToAllTechnicians -eq $true -and
+			$Body.allowedTechnicianRoles.Count -eq 2 -and
+			$Body.fields.Count -eq 1
+		}
+	}
+
+	It 'returns created template when -show is supplied' {
+		$field = [pscustomobject]@{
+			fieldName = 'Hostname'
+			fieldType = 'TEXT'
+		}
+		$field.PSObject.TypeNames.Insert(0, 'DocumentTemplateField')
+		$fields = @($field)
+
+		$result = New-NinjaOneDocumentTemplate -Name 'Template A' -fields $fields -show -Confirm:$false
+
+		$result.id | Should -Be 500
+		$result.name | Should -Be 'Template A'
+	}
+
+	It 'delegates POST failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -MockWith { throw 'doc-template-create-failed' }
+		$field = [pscustomobject]@{
+			fieldName = 'Hostname'
+			fieldType = 'TEXT'
+		}
+		$field.PSObject.TypeNames.Insert(0, 'DocumentTemplateField')
+		$fields = @($field)
+
+		{ New-NinjaOneDocumentTemplate -Name 'Template A' -fields $fields -Confirm:$false } | Should -Throw '*doc-template-create-failed*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Set-NinjaOneDocumentTemplate' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -MockWith { 204 }
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'calls POST v2/document-templates/{id} with updated properties' {
+		$fields = @(
+			@{
+				fieldName = 'Hostname'
+				fieldType = 'TEXT'
+			}
+		)
+
+		$null = Set-NinjaOneDocumentTemplate -documentTemplateId 5 -Name 'Template B' -description 'updated' -allowMultiple -mandatory -fields $fields -availableToAllTechnicians -allowedTechnicianRoles @(1) -Confirm:$false
+
+		Assert-MockCalled -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/document-templates/5' -and
+			$Body.name -eq 'Template B' -and
+			$Body.description -eq 'updated' -and
+			$Body.allowMultiple -eq $true -and
+			$Body.mandatory -eq $true -and
+			$Body.availableToAllTechnicians -eq $true -and
+			$Body.allowedTechnicianRoles.Count -eq 1 -and
+			$Body.fields.Count -eq 1
+		}
+	}
+
+	It 'returns update response when -show is supplied' {
+		Mock -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -MockWith {
+			[pscustomobject]@{ id = 5; name = 'Template B' }
+		}
+		$fields = @(
+			@{
+				fieldName = 'Hostname'
+				fieldType = 'TEXT'
+			}
+		)
+
+		$result = Set-NinjaOneDocumentTemplate -documentTemplateId 5 -Name 'Template B' -fields $fields -show -Confirm:$false
+
+		$result.id | Should -Be 5
+	}
+
+	It 'throws validation error when DROPDOWN field has no fieldContent' {
+		$fields = @(
+			@{
+				fieldName = 'Choice'
+				fieldType = 'DROPDOWN'
+			}
+		)
+
+		{ Set-NinjaOneDocumentTemplate -documentTemplateId 5 -Name 'Template B' -fields $fields -Confirm:$false } | Should -Throw '*Field content must be specified*'
+	}
+
+	It 'throws validation error when DROPDOWN fieldContent has no values' {
+		$fields = @(
+			@{
+				fieldName = 'Choice'
+				fieldType = 'DROPDOWN'
+				fieldContent = [pscustomobject]@{
+					required = $true
+				}
+			}
+		)
+
+		{ Set-NinjaOneDocumentTemplate -documentTemplateId 5 -Name 'Template B' -fields $fields -Confirm:$false } | Should -Throw '*Field content values must be specified*'
+	}
+
+	It 'delegates request failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -MockWith { throw 'doc-template-update-failed' }
+		$fields = @(
+			@{
+				fieldName = 'Hostname'
+				fieldType = 'TEXT'
+			}
+		)
+
+		{ Set-NinjaOneDocumentTemplate -documentTemplateId 5 -Name 'Template B' -fields $fields -Confirm:$false } | Should -Throw '*doc-template-update-failed*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
 Get-Module -Name $ModuleName | Remove-Module -Force -ErrorAction SilentlyContinue
 Import-Module $ModulePath -Force
 

--- a/Tests/NinjaOne.Public.Tests.ps1
+++ b/Tests/NinjaOne.Public.Tests.ps1
@@ -1266,6 +1266,281 @@ Describe 'Get-NinjaOneSoftwarePatches' {
 	}
 }
 
+Describe 'New-NinjaOneCustomField' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -MockWith {
+			[pscustomobject]@{ fieldName = 'department'; type = 'TEXT' }
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'calls POST v2/custom-fields with the supplied body' {
+		$body = @{ fieldName = 'department'; type = 'TEXT' }
+
+		$null = New-NinjaOneCustomField -customField $body -Confirm:$false
+
+		Assert-MockCalled -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/custom-fields' -and
+			$Body.fieldName -eq 'department' -and
+			$Body.type -eq 'TEXT'
+		}
+	}
+
+	It 'returns the created custom field' {
+		$body = @{ fieldName = 'department'; type = 'TEXT' }
+
+		$result = New-NinjaOneCustomField -customField $body -Confirm:$false
+
+		$result.fieldName | Should -Be 'department'
+	}
+
+	It 'does not call POST when -WhatIf is supplied' {
+		$body = @{ fieldName = 'department'; type = 'TEXT' }
+
+		$null = New-NinjaOneCustomField -customField $body -WhatIf
+
+		Assert-MockCalled -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -Times 0
+	}
+
+	It 'delegates request failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -MockWith { throw 'custom-field-create-failed' }
+		$body = @{ fieldName = 'department'; type = 'TEXT' }
+
+		{ New-NinjaOneCustomField -customField $body -Confirm:$false } | Should -Throw '*custom-field-create-failed*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Set-NinjaOneDeviceMaintenance' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOnePUTRequest -ModuleName $ModuleName -MockWith { 204 }
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'calls PUT v2/device/{id}/maintenance with DateTime values converted to Unix epoch' {
+		$start = [datetime]'2024-01-01T00:00:00Z'
+		$end = [datetime]'2024-01-01T01:00:00Z'
+
+		$null = Set-NinjaOneDeviceMaintenance -deviceId 81 -disabledFeatures @('ALERTS') -start $start -end $end -Confirm:$false
+
+		Assert-MockCalled -CommandName New-NinjaOnePUTRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/device/81/maintenance' -and
+			$Body.disabledFeatures[0] -eq 'ALERTS' -and
+			$Body.start -is [int] -and
+			$Body.end -is [int]
+		}
+	}
+
+	It 'calls PUT with unixStart and unixEnd values' {
+		$null = Set-NinjaOneDeviceMaintenance -deviceId 81 -disabledFeatures @('PATCHING') -unixStart 1704067200 -unixEnd 1704070800 -Confirm:$false
+
+		Assert-MockCalled -CommandName New-NinjaOnePUTRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/device/81/maintenance' -and
+			$Body.start -eq 1704067200 -and
+			$Body.end -eq 1704070800
+		}
+	}
+
+	It 'throws when no end or unixEnd is specified' {
+		{ Set-NinjaOneDeviceMaintenance -deviceId 81 -disabledFeatures @('ALERTS') -start ([datetime]'2024-01-01T00:00:00Z') -Confirm:$false } | Should -Throw '*An end date/time must be specified*'
+	}
+
+	It 'delegates PUT failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOnePUTRequest -ModuleName $ModuleName -MockWith { throw 'maintenance-update-failed' }
+
+		{ Set-NinjaOneDeviceMaintenance -deviceId 81 -disabledFeatures @('ALERTS') -unixStart 1704067200 -unixEnd 1704070800 -Confirm:$false } | Should -Throw '*maintenance-update-failed*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'New-NinjaOneOrganisation' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith {
+			[System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+		}
+		Mock -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -MockWith {
+			[pscustomobject]@{ id = 501; name = 'Contoso Ltd' }
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'calls POST v2/organizations with organisation body and optional template query' {
+		$body = @{ name = 'Contoso Ltd'; description = 'Test org' }
+
+		$null = New-NinjaOneOrganisation -templateOrganisationId '12' -organisation $body -Confirm:$false
+
+		Assert-MockCalled -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/organizations' -and
+			$Body.name -eq 'Contoso Ltd'
+		}
+		Assert-MockCalled -CommandName New-NinjaOneQuery -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Parameters.ContainsKey('templateOrganisationId') -and -not $Parameters.ContainsKey('organisation')
+		}
+	}
+
+	It 'returns created organisation when -show is supplied' {
+		$body = @{ name = 'Contoso Ltd' }
+
+		$result = New-NinjaOneOrganisation -organisation $body -show -Confirm:$false
+
+		$result.id | Should -Be 501
+	}
+
+	It 'delegates POST failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -MockWith { throw 'organisation-create-failed' }
+		$body = @{ name = 'Contoso Ltd' }
+
+		{ New-NinjaOneOrganisation -organisation $body -Confirm:$false } | Should -Throw '*organisation-create-failed*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Get-NinjaOneCustomFields' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith {
+			[System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+		}
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@([pscustomobject]@{ id = 1; field = 'department' })
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'uses v2/queries/custom-fields for default parameter set' {
+		$null = Get-NinjaOneCustomFields
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/queries/custom-fields'
+		}
+	}
+
+	It 'uses v2/queries/custom-fields-detailed when -detailed is supplied in default set' {
+		$null = Get-NinjaOneCustomFields -detailed
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/queries/custom-fields-detailed'
+		}
+		Assert-MockCalled -CommandName New-NinjaOneQuery -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			-not $Parameters.ContainsKey('detailed')
+		}
+	}
+
+	It 'uses v2/queries/scoped-custom-fields for scoped parameter set' {
+		$null = Get-NinjaOneCustomFields -scopes @('NODE')
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/queries/scoped-custom-fields'
+		}
+	}
+
+	It 'uses v2/queries/scoped-custom-fields-detailed when scoped and detailed are supplied' {
+		$null = Get-NinjaOneCustomFields -scopes @('NODE') -detailed
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/queries/scoped-custom-fields-detailed'
+		}
+	}
+
+	It 'promotes updatedAfterUnixEpoch to updatedAfter in query parameters' {
+		$null = Get-NinjaOneCustomFields -updatedAfterUnixEpoch 1619712000000
+
+		Assert-MockCalled -CommandName New-NinjaOneQuery -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Parameters.ContainsKey('updatedAfter') -and -not $Parameters.ContainsKey('updatedAfterUnixEpoch')
+		}
+	}
+
+	It 'delegates no-result failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { $null }
+
+		{ Get-NinjaOneCustomFields } | Should -Throw '*No custom fields found*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Get-NinjaOneInstanceCapabilities' {
+	BeforeEach {
+		Mock -CommandName Get-NinjaOneInstanceCapabilitiesInternal -ModuleName $ModuleName -MockWith {
+			param($baseUrl, $Force)
+			[pscustomobject]@{
+				BaseUrl = $baseUrl
+				Version = '1.2.3'
+				SpecUrl = ($baseUrl.TrimEnd('/') + '/api/docs-2.0/openapi.json')
+				RetrievedAt = [datetime]'2024-01-01T00:00:00Z'
+				Paths = @{
+					'/v2/devices' = @('GET')
+					'/v2/organizations' = @('GET', 'POST')
+				}
+			}
+		}
+	}
+
+	It 'returns summary fields when baseUrl is provided' {
+		$result = Get-NinjaOneInstanceCapabilities -baseUrl 'https://fed.ninjarmm.com'
+
+		$result.BaseUrl | Should -Be 'https://fed.ninjarmm.com'
+		$result.AppVersion | Should -Be '1.2.3'
+		$result.PathCount | Should -Be 2
+		Assert-MockCalled -CommandName Get-NinjaOneInstanceCapabilitiesInternal -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$baseUrl -eq 'https://fed.ninjarmm.com' -and -not $Force
+		}
+	}
+
+	It 'passes refresh switch through as Force to internal loader' {
+		$null = Get-NinjaOneInstanceCapabilities -baseUrl 'https://fed.ninjarmm.com' -refresh
+
+		Assert-MockCalled -CommandName Get-NinjaOneInstanceCapabilitiesInternal -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$baseUrl -eq 'https://fed.ninjarmm.com' -and $Force
+		}
+	}
+
+	It 'includes paths when includePaths is supplied' {
+		$result = Get-NinjaOneInstanceCapabilities -baseUrl 'https://fed.ninjarmm.com' -includePaths
+
+		$result.Paths.Keys.Count | Should -Be 2
+	}
+
+	It 'classifies cmdlets as unknown when metadata is absent with includeCmdlets' {
+		Mock -CommandName Get-Module -ModuleName $ModuleName -MockWith {
+			[pscustomobject]@{
+				ExportedFunctions = @{
+					'Get-FakeOne' = $null
+					'Set-FakeTwo' = $null
+				}
+			}
+		}
+		Mock -CommandName Get-Command -ModuleName $ModuleName -MockWith {
+			@(
+				[pscustomobject]@{ Name = 'Get-FakeOne'; ScriptBlock = [scriptblock]::Create('param()') },
+				[pscustomobject]@{ Name = 'Set-FakeTwo'; ScriptBlock = [scriptblock]::Create('param()') }
+			)
+		}
+
+		$result = Get-NinjaOneInstanceCapabilities -baseUrl 'https://fed.ninjarmm.com' -includeCmdlets
+
+		$result.UnknownCmdletCount | Should -Be 2
+		$result.SupportedCmdletCount | Should -Be 0
+		$result.UnsupportedCmdletCount | Should -Be 0
+	}
+
+	It 'throws when internal loader returns null capabilities' {
+		Mock -CommandName Get-NinjaOneInstanceCapabilitiesInternal -ModuleName $ModuleName -MockWith { $null }
+
+		{ Get-NinjaOneInstanceCapabilities -baseUrl 'https://fed.ninjarmm.com' } | Should -Throw '*Unable to retrieve OpenAPI spec*'
+	}
+}
+
 Get-Module -Name $ModuleName | Remove-Module -Force -ErrorAction SilentlyContinue
 Import-Module $ModulePath -Force
 

--- a/Tests/NinjaOne.Public.Tests.ps1
+++ b/Tests/NinjaOne.Public.Tests.ps1
@@ -1003,3 +1003,100 @@ Describe 'Get-NinjaOnePolicies' {
 		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
 	}
 }
+
+Describe 'Get-NinjaOneRoles' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith {
+			[System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+		}
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@([pscustomobject]@{ id = 1; name = 'Server' })
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'uses the roles endpoint' {
+		$null = Get-NinjaOneRoles
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/roles'
+		}
+	}
+
+	It 'delegates no-result failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { $null }
+
+		{ Get-NinjaOneRoles } | Should -Throw '*No roles found*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Get-NinjaOneTasks' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith {
+			[System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+		}
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@([pscustomobject]@{ id = 1; name = 'Daily Health Check' })
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'uses the tasks endpoint' {
+		$null = Get-NinjaOneTasks
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/tasks'
+		}
+	}
+
+	It 'delegates no-result failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { $null }
+
+		{ Get-NinjaOneTasks } | Should -Throw '*No tasks found*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Get-NinjaOneNotificationChannels' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@([pscustomobject]@{ id = 1; name = 'Email' })
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'uses the notification channels endpoint by default' {
+		$null = Get-NinjaOneNotificationChannels
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/notification-channels'
+		}
+	}
+
+	It 'uses the enabled notification channels endpoint when -enabled is supplied' {
+		$null = Get-NinjaOneNotificationChannels -enabled
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/notification-channels/enabled'
+		}
+	}
+
+	It 'delegates upstream request failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			throw 'notification-request-failed'
+		}
+
+		{ Get-NinjaOneNotificationChannels } | Should -Throw '*No notification channels found*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}

--- a/Tests/NinjaOne.Public.Tests.ps1
+++ b/Tests/NinjaOne.Public.Tests.ps1
@@ -968,6 +968,145 @@ Describe 'Set-NinjaOneDocumentTemplate' {
 	}
 }
 
+Describe 'Get-NinjaOneSoftwarePatchInstalls' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith {
+			[System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+		}
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@([pscustomobject]@{ id = 1; status = 'INSTALLED' })
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'calls the software patch installs query endpoint' {
+		$null = Get-NinjaOneSoftwarePatchInstalls
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/queries/software-patch-installs'
+		}
+	}
+
+	It 'promotes installedBeforeUnixEpoch to installedBefore in query parameters' {
+		$null = Get-NinjaOneSoftwarePatchInstalls -installedBeforeUnixEpoch 1619712000
+
+		Assert-MockCalled -CommandName New-NinjaOneQuery -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Parameters.ContainsKey('installedBefore') -and -not $Parameters.ContainsKey('installedBeforeUnixEpoch')
+		}
+	}
+
+	It 'promotes timeStampUnixEpoch to timeStamp in query parameters' {
+		$null = Get-NinjaOneSoftwarePatchInstalls -timeStampUnixEpoch 1619712000
+
+		Assert-MockCalled -CommandName New-NinjaOneQuery -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Parameters.ContainsKey('timeStamp') -and -not $Parameters.ContainsKey('timeStampUnixEpoch')
+		}
+	}
+
+	It 'delegates no-result failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { $null }
+
+		{ Get-NinjaOneSoftwarePatchInstalls } | Should -Throw '*No software patch installs found*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Get-NinjaOneOSPatchInstalls' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith {
+			[System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+		}
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@([pscustomobject]@{ id = 1; status = 'INSTALLED' })
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'calls the OS patch installs query endpoint' {
+		$null = Get-NinjaOneOSPatchInstalls
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/queries/os-patch-installs'
+		}
+	}
+
+	It 'promotes installedAfterUnixEpoch to installedAfter in query parameters' {
+		$null = Get-NinjaOneOSPatchInstalls -installedAfterUnixEpoch 1619712000
+
+		Assert-MockCalled -CommandName New-NinjaOneQuery -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Parameters.ContainsKey('installedAfter') -and -not $Parameters.ContainsKey('installedAfterUnixEpoch')
+		}
+	}
+
+	It 'promotes timeStampUnixEpoch to timeStamp in query parameters' {
+		$null = Get-NinjaOneOSPatchInstalls -timeStampUnixEpoch 1619712000
+
+		Assert-MockCalled -CommandName New-NinjaOneQuery -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Parameters.ContainsKey('timeStamp') -and -not $Parameters.ContainsKey('timeStampUnixEpoch')
+		}
+	}
+
+	It 'delegates no-result failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { $null }
+
+		{ Get-NinjaOneOSPatchInstalls } | Should -Throw '*No OS patch installs found*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Set-NinjaOneCustomField' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOnePUTRequest -ModuleName $ModuleName -MockWith {
+			[pscustomobject]@{ fieldName = 'department'; updated = $true }
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'calls PUT v2/custom-fields/field-name/{fieldName} with the supplied body' {
+		$body = @{ description = 'Department of the user' }
+
+		$null = Set-NinjaOneCustomField -fieldName 'department' -customField $body -Confirm:$false
+
+		Assert-MockCalled -CommandName New-NinjaOnePUTRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/custom-fields/field-name/department' -and
+			$Body.description -eq 'Department of the user'
+		}
+	}
+
+	It 'returns the PUT response' {
+		$body = @{ description = 'Department of the user' }
+
+		$result = Set-NinjaOneCustomField -fieldName 'department' -customField $body -Confirm:$false
+
+		$result.updated | Should -Be $true
+	}
+
+	It 'does not call PUT when -WhatIf is used' {
+		$body = @{ description = 'Department of the user' }
+
+		$null = Set-NinjaOneCustomField -fieldName 'department' -customField $body -WhatIf
+
+		Assert-MockCalled -CommandName New-NinjaOnePUTRequest -ModuleName $ModuleName -Times 0
+	}
+
+	It 'delegates request failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOnePUTRequest -ModuleName $ModuleName -MockWith { throw 'custom-field-update-failed' }
+		$body = @{ description = 'Department of the user' }
+
+		{ Set-NinjaOneCustomField -fieldName 'department' -customField $body -Confirm:$false } | Should -Throw '*custom-field-update-failed*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
 Get-Module -Name $ModuleName | Remove-Module -Force -ErrorAction SilentlyContinue
 Import-Module $ModulePath -Force
 

--- a/Tests/NinjaOne.Public.Tests.ps1
+++ b/Tests/NinjaOne.Public.Tests.ps1
@@ -1541,6 +1541,266 @@ Describe 'Get-NinjaOneInstanceCapabilities' {
 	}
 }
 
+Describe 'New-NinjaOneSecureRelation' {
+	BeforeAll {
+		Mock -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -MockWith {
+			[PSCustomObject]@{ id = 42; name = 'TestSecret'; entityType = 'ORGANIZATION'; entityId = 1 }
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith { param($ErrorRecord); throw $ErrorRecord.Exception }
+	}
+
+	It 'posts to the correct resource endpoint' {
+		New-NinjaOneSecureRelation -entityType 'ORGANIZATION' -entityId 1 -secureValueName 'TestSecret'
+
+		Should -Invoke -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -ParameterFilter {
+			$Resource -eq 'v2/related-items/entity/ORGANIZATION/1/secure'
+		} -Times 1 -Exactly
+	}
+
+	It 'returns result when -show is used' {
+		$result = New-NinjaOneSecureRelation -entityType 'ORGANIZATION' -entityId 1 -secureValueName 'TestSecret' -show
+
+		$result.name | Should -Be 'TestSecret'
+	}
+
+	It 'includes optional body fields when provided' {
+		New-NinjaOneSecureRelation -entityType 'NODE' -entityId 5 -secureValueName 'S' -secureValueURL 'https://example.com' -secureValueUsername 'admin' -secureValuePassword 'pass' -secureValueNotes 'notes'
+
+		Should -Invoke -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -ParameterFilter {
+			$Resource -eq 'v2/related-items/entity/NODE/5/secure' -and
+			$Body.url -eq 'https://example.com' -and
+			$Body.username -eq 'admin' -and
+			$Body.notes -eq 'notes'
+		} -Times 1 -Exactly
+	}
+
+	It 'skips POST when WhatIf is used' {
+		New-NinjaOneSecureRelation -entityType 'ORGANIZATION' -entityId 1 -secureValueName 'S' -WhatIf
+
+		Should -Invoke -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -Times 0 -Exactly
+	}
+
+	It 'surfaces errors via New-NinjaOneError' {
+		Mock -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -MockWith { throw 'API error' }
+
+		{ New-NinjaOneSecureRelation -entityType 'ORGANIZATION' -entityId 1 -secureValueName 'S' } | Should -Throw
+	}
+}
+
+Describe 'New-NinjaOneOrganisationDocument' {
+	BeforeAll {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith { [System.Web.HttpUtility]::ParseQueryString([String]::Empty) }
+		Mock -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -MockWith {
+			[PSCustomObject]@{ id = 10; documentName = 'Doc1'; organizationId = 3 }
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith { param($ErrorRecord); throw $ErrorRecord.Exception }
+	}
+
+	It 'posts to the correct resource endpoint' {
+		$doc = [PSCustomObject]@{ documentName = 'Doc1'; fields = @{} }
+		New-NinjaOneOrganisationDocument -organisationId '3' -documentTemplateId '7' -organisationDocument $doc
+
+		Should -Invoke -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -ParameterFilter {
+			$Resource -eq 'v2/organization/3/template/7/document'
+		} -Times 1 -Exactly
+	}
+
+	It 'returns result when -show is used' {
+		$doc = [PSCustomObject]@{ documentName = 'Doc1'; fields = @{} }
+		$result = New-NinjaOneOrganisationDocument -organisationId '3' -documentTemplateId '7' -organisationDocument $doc -show
+
+		$result.documentName | Should -Be 'Doc1'
+	}
+
+	It 'skips POST when WhatIf is used' {
+		$doc = [PSCustomObject]@{ documentName = 'Doc1'; fields = @{} }
+		New-NinjaOneOrganisationDocument -organisationId '3' -documentTemplateId '7' -organisationDocument $doc -WhatIf
+
+		Should -Invoke -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -Times 0 -Exactly
+	}
+
+	It 'surfaces errors via New-NinjaOneError' {
+		Mock -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -MockWith { throw 'API error' }
+		$doc = [PSCustomObject]@{ documentName = 'Doc1'; fields = @{} }
+
+		{ New-NinjaOneOrganisationDocument -organisationId '3' -documentTemplateId '7' -organisationDocument $doc } | Should -Throw
+	}
+}
+
+Describe 'New-NinjaOneOrganisationDocuments' {
+	BeforeAll {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith { [System.Web.HttpUtility]::ParseQueryString([String]::Empty) }
+		Mock -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -MockWith {
+			@([PSCustomObject]@{ id = 11; organizationId = 4 }, [PSCustomObject]@{ id = 12; organizationId = 5 })
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith { param($ErrorRecord); throw $ErrorRecord.Exception }
+	}
+
+	It 'posts to the correct resource endpoint' {
+		$docs = @([PSCustomObject]@{ documentName = 'D1'; organizationId = 4 })
+		New-NinjaOneOrganisationDocuments -organisationDocuments $docs
+
+		Should -Invoke -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -ParameterFilter {
+			$Resource -eq 'v2/organization/documents'
+		} -Times 1 -Exactly
+	}
+
+	It 'returns result when -show is used' {
+		$docs = @([PSCustomObject]@{ documentName = 'D1'; organizationId = 4 })
+		$result = New-NinjaOneOrganisationDocuments -organisationDocuments $docs -show
+
+		$result | Should -Not -BeNullOrEmpty
+	}
+
+	It 'skips POST when WhatIf is used' {
+		$docs = @([PSCustomObject]@{ documentName = 'D1'; organizationId = 4 })
+		New-NinjaOneOrganisationDocuments -organisationDocuments $docs -WhatIf
+
+		Should -Invoke -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -Times 0 -Exactly
+	}
+
+	It 'surfaces errors via New-NinjaOneError' {
+		Mock -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -MockWith { throw 'API error' }
+		$docs = @([PSCustomObject]@{ documentName = 'D1'; organizationId = 4 })
+
+		{ New-NinjaOneOrganisationDocuments -organisationDocuments $docs } | Should -Throw
+	}
+}
+
+Describe 'New-NinjaOnePolicy' {
+	BeforeAll {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith { [System.Web.HttpUtility]::ParseQueryString([String]::Empty) }
+		Mock -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -MockWith {
+			[PSCustomObject]@{ id = 20; name = 'TestPolicy'; nodeClass = 'WINDOWS_SERVER' }
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith { param($ErrorRecord); throw $ErrorRecord.Exception }
+	}
+
+	It 'posts to the correct resource endpoint' {
+		$policy = [PSCustomObject]@{ name = 'TestPolicy'; nodeClass = 'WINDOWS_SERVER'; enabled = $true }
+		New-NinjaOnePolicy -mode 'NEW' -policy $policy
+
+		Should -Invoke -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -ParameterFilter {
+			$Resource -eq 'v2/policies'
+		} -Times 1 -Exactly
+	}
+
+	It 'returns result when -show is used' {
+		$policy = [PSCustomObject]@{ name = 'TestPolicy'; nodeClass = 'WINDOWS_SERVER'; enabled = $true }
+		$result = New-NinjaOnePolicy -mode 'NEW' -policy $policy -show
+
+		$result.name | Should -Be 'TestPolicy'
+	}
+
+	It 'throws in begin block when CHILD mode has no parentPolicyId' {
+		$policy = [PSCustomObject]@{ name = 'ChildPolicy'; nodeClass = 'WINDOWS_SERVER' }
+
+		{ New-NinjaOnePolicy -mode 'CHILD' -policy $policy } | Should -Throw '*parent policy id*'
+	}
+
+	It 'throws in begin block when COPY mode has no templatePolicyId' {
+		$policy = [PSCustomObject]@{ name = 'CopyPolicy'; nodeClass = 'WINDOWS_SERVER' }
+
+		{ New-NinjaOnePolicy -mode 'COPY' -policy $policy } | Should -Throw '*template policy id*'
+	}
+
+	It 'skips POST when WhatIf is used' {
+		$policy = [PSCustomObject]@{ name = 'TestPolicy'; nodeClass = 'WINDOWS_SERVER'; enabled = $true }
+		New-NinjaOnePolicy -mode 'NEW' -policy $policy -WhatIf
+
+		Should -Invoke -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -Times 0 -Exactly
+	}
+
+	It 'surfaces errors via New-NinjaOneError' {
+		Mock -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -MockWith { throw 'API error' }
+		$policy = [PSCustomObject]@{ name = 'TestPolicy'; nodeClass = 'WINDOWS_SERVER'; enabled = $true }
+
+		{ New-NinjaOnePolicy -mode 'NEW' -policy $policy } | Should -Throw
+	}
+}
+
+Describe 'Get-NinjaOneAntiVirusStatus' {
+	BeforeAll {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith { [System.Web.HttpUtility]::ParseQueryString([String]::Empty) }
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@([PSCustomObject]@{ deviceId = 1; productName = 'Defender'; productState = 'ON' })
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith { param($ErrorRecord); throw $ErrorRecord.Exception }
+	}
+
+	It 'calls the correct endpoint' {
+		Get-NinjaOneAntiVirusStatus
+
+		Should -Invoke -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -ParameterFilter {
+			$Resource -eq 'v2/queries/antivirus-status'
+		} -Times 1 -Exactly
+	}
+
+	It 'returns results' {
+		$result = Get-NinjaOneAntiVirusStatus
+
+		$result | Should -Not -BeNullOrEmpty
+		$result[0].productName | Should -Be 'Defender'
+	}
+
+	It 'applies deviceFilter parameter' {
+		Get-NinjaOneAntiVirusStatus -deviceFilter 'org = 1'
+
+		Should -Invoke -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -Exactly
+	}
+
+	It 'converts timeStampUnixEpoch to timeStamp' {
+		Get-NinjaOneAntiVirusStatus -timeStampUnixEpoch 1619712000
+
+		Should -Invoke -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -Exactly
+	}
+
+	It 'throws when no results returned' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { $null }
+
+		{ Get-NinjaOneAntiVirusStatus } | Should -Throw
+	}
+}
+
+Describe 'New-NinjaOneWindowsEventPolicyCondition' {
+	BeforeAll {
+		Mock -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -MockWith {
+			[PSCustomObject]@{ id = 99; displayName = 'TestCondition'; policyId = 15 }
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith { param($ErrorRecord); throw $ErrorRecord.Exception }
+	}
+
+	It 'posts to the correct resource endpoint' {
+		$condition = [PSCustomObject]@{ displayName = 'TestCondition'; enabled = $true }
+		New-NinjaOneWindowsEventPolicyCondition -policyId 15 -windowsEventPolicyCondition $condition
+
+		Should -Invoke -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -ParameterFilter {
+			$Resource -eq 'v2/policies/15/condition/windows-event'
+		} -Times 1 -Exactly
+	}
+
+	It 'returns result when -show is used' {
+		$condition = [PSCustomObject]@{ displayName = 'TestCondition'; enabled = $true }
+		$result = New-NinjaOneWindowsEventPolicyCondition -policyId 15 -windowsEventPolicyCondition $condition -show
+
+		$result.displayName | Should -Be 'TestCondition'
+	}
+
+	It 'skips POST when WhatIf is used' {
+		$condition = [PSCustomObject]@{ displayName = 'TestCondition'; enabled = $true }
+		New-NinjaOneWindowsEventPolicyCondition -policyId 15 -windowsEventPolicyCondition $condition -WhatIf
+
+		Should -Invoke -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -Times 0 -Exactly
+	}
+
+	It 'surfaces errors via New-NinjaOneError' {
+		Mock -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -MockWith { throw 'API error' }
+		$condition = [PSCustomObject]@{ displayName = 'TestCondition'; enabled = $true }
+
+		{ New-NinjaOneWindowsEventPolicyCondition -policyId 15 -windowsEventPolicyCondition $condition } | Should -Throw
+	}
+}
+
 Get-Module -Name $ModuleName | Remove-Module -Force -ErrorAction SilentlyContinue
 Import-Module $ModulePath -Force
 

--- a/Tests/NinjaOne.Public.Tests.ps1
+++ b/Tests/NinjaOne.Public.Tests.ps1
@@ -314,3 +314,213 @@ Describe 'Get-NinjaOneUsers' {
 # - Test error scenarios comprehensively across all functions
 # - Implement performance benchmarking for large dataset handling
 #
+
+Describe 'Get-NinjaOneAlerts' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith {
+			[System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+		}
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@(
+				[pscustomobject]@{ uid = 'alert-1'; message = 'CPU high' }
+			)
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'uses the global alerts endpoint when deviceId is not supplied' {
+		$result = Get-NinjaOneAlerts
+
+		@($result).Count | Should -Be 1
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/alerts'
+		}
+	}
+
+	It 'uses the device alerts endpoint when deviceId is supplied' {
+		$result = Get-NinjaOneAlerts -deviceId 42
+
+		@($result).Count | Should -Be 1
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/device/42/alerts'
+		}
+	}
+
+	It 'passes sourceType as a query string parameter' {
+		Get-NinjaOneAlerts -sourceType 'CONDITION_CUSTOM_FIELD'
+
+		Assert-MockCalled -CommandName New-NinjaOneQuery -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Parameters.ContainsKey('sourceType')
+		}
+	}
+
+	It 'passes parseDateTime through to the GET request' {
+		Get-NinjaOneAlerts -parseDateTime
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$ParseDateTime -eq $true
+		}
+	}
+
+	It 'delegates no-result global failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { throw 'Not found' }
+
+		{ Get-NinjaOneAlerts } | Should -Throw '*No alerts found*'
+
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+
+	It 'delegates no-result device failures to New-NinjaOneError with device id' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { throw 'Not found' }
+
+		{ Get-NinjaOneAlerts -deviceId 7 } | Should -Throw '*No alerts found for device 7*'
+
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Get-NinjaOneJobs' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith {
+			[System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+		}
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@(
+				[pscustomobject]@{ id = 1001; type = 'SOFTWARE_PATCH_MANAGEMENT'; status = 'COMPLETED' }
+			)
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'uses the global jobs endpoint when deviceId is not supplied' {
+		$result = Get-NinjaOneJobs
+
+		@($result).Count | Should -Be 1
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/jobs'
+		}
+	}
+
+	It 'uses the device jobs endpoint when deviceId is supplied' {
+		$result = Get-NinjaOneJobs -deviceId 5
+
+		@($result).Count | Should -Be 1
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/device/5/jobs'
+		}
+	}
+
+	It 'passes jobType as a query string parameter' {
+		Get-NinjaOneJobs -jobType 'SOFTWARE_PATCH_MANAGEMENT'
+
+		Assert-MockCalled -CommandName New-NinjaOneQuery -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Parameters.ContainsKey('jobType')
+		}
+	}
+
+	It 'passes parseDateTime through to the GET request' {
+		Get-NinjaOneJobs -parseDateTime
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$ParseDateTime -eq $true
+		}
+	}
+
+	It 'delegates no-result global failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { $null }
+
+		{ Get-NinjaOneJobs } | Should -Throw '*No jobs found*'
+
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+
+	It 'delegates no-result device failures to New-NinjaOneError with device id' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { $null }
+
+		{ Get-NinjaOneJobs -deviceId 5 } | Should -Throw '*No jobs found for device 5*'
+
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Get-NinjaOneSoftwareInventory' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith {
+			[System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+		}
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@(
+				[pscustomobject]@{ id = 1; name = 'Microsoft Teams'; version = '1.6.0' }
+			)
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'always uses the software query endpoint' {
+		$result = Get-NinjaOneSoftwareInventory
+
+		@($result).Count | Should -Be 1
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/queries/software'
+		}
+	}
+
+	It 'passes deviceFilter as a query string parameter' {
+		Get-NinjaOneSoftwareInventory -deviceFilter 'org = 1'
+
+		Assert-MockCalled -CommandName New-NinjaOneQuery -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Parameters.ContainsKey('deviceFilter')
+		}
+	}
+
+	It 'converts installedBefore DateTime to Unix epoch before querying' {
+		$dt = [datetime]'2024-05-01T00:00:00Z'
+		Get-NinjaOneSoftwareInventory -installedBefore $dt
+
+		Assert-MockCalled -CommandName New-NinjaOneQuery -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Parameters.ContainsKey('installedBefore')
+		}
+	}
+
+	It 'converts installedAfter DateTime to Unix epoch before querying' {
+		$dt = [datetime]'2024-01-01T00:00:00Z'
+		Get-NinjaOneSoftwareInventory -installedAfter $dt
+
+		Assert-MockCalled -CommandName New-NinjaOneQuery -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Parameters.ContainsKey('installedAfter')
+		}
+	}
+
+	It 'removes installedBeforeUnixEpoch from parameters and promotes to installedBefore' {
+		Get-NinjaOneSoftwareInventory -installedBeforeUnixEpoch 1619712000
+
+		Assert-MockCalled -CommandName New-NinjaOneQuery -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			(-not $Parameters.ContainsKey('installedBeforeUnixEpoch')) -and $Parameters.ContainsKey('installedBefore')
+		}
+	}
+
+	It 'removes installedAfterUnixEpoch from parameters and promotes to installedAfter' {
+		Get-NinjaOneSoftwareInventory -installedAfterUnixEpoch 1619712000
+
+		Assert-MockCalled -CommandName New-NinjaOneQuery -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			(-not $Parameters.ContainsKey('installedAfterUnixEpoch')) -and $Parameters.ContainsKey('installedAfter')
+		}
+	}
+
+	It 'delegates no-result failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { $null }
+
+		{ Get-NinjaOneSoftwareInventory } | Should -Throw '*No software inventory found*'
+
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}

--- a/Tests/NinjaOne.Public.Tests.ps1
+++ b/Tests/NinjaOne.Public.Tests.ps1
@@ -1100,3 +1100,180 @@ Describe 'Get-NinjaOneNotificationChannels' {
 		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
 	}
 }
+
+Describe 'Get-NinjaOneAutomations' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith {
+			[System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+		}
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@([pscustomobject]@{ id = 1; name = 'Reboot Device' })
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'uses the automation scripts endpoint' {
+		$null = Get-NinjaOneAutomations
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/automation/scripts'
+		}
+	}
+
+	It 'passes languageTag as a query parameter' {
+		$null = Get-NinjaOneAutomations -languageTag 'en'
+
+		Assert-MockCalled -CommandName New-NinjaOneQuery -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Parameters.ContainsKey('languageTag')
+		}
+	}
+
+	It 'delegates upstream request failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			throw 'automation-request-failed'
+		}
+
+		{ Get-NinjaOneAutomations } | Should -Throw '*No automation scripts found*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Get-NinjaOneContact' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith {
+			[System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+		}
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			[pscustomobject]@{ id = 42; name = 'Sam Contact' }
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'uses the contact endpoint with the provided id' {
+		$null = Get-NinjaOneContact -id 42
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/contact/42'
+		}
+	}
+
+	It 'delegates no-result failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { $null }
+
+		{ Get-NinjaOneContact -id 42 } | Should -Throw '*Contact with id 42 not found*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Get-NinjaOneDeviceCustomFields' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith {
+			[System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+		}
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@([pscustomobject]@{ scope = 'node'; fieldName = 'assetTag' })
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'uses the global custom fields endpoint by default' {
+		$null = Get-NinjaOneDeviceCustomFields
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/device-custom-fields'
+		}
+	}
+
+	It 'uses the device custom fields endpoint when deviceId is supplied' {
+		$null = Get-NinjaOneDeviceCustomFields -deviceId 99
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/device/99/custom-fields'
+		}
+	}
+
+	It 'passes scope as a query parameter' {
+		$null = Get-NinjaOneDeviceCustomFields -scope 'node'
+
+		Assert-MockCalled -CommandName New-NinjaOneQuery -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Parameters.ContainsKey('scope')
+		}
+	}
+}
+
+Describe 'Get-NinjaOneSoftwareProducts' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith {
+			[System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+		}
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@([pscustomobject]@{ id = 1; name = 'Microsoft Edge' })
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'uses the global software products endpoint when deviceId is not supplied' {
+		$null = Get-NinjaOneSoftwareProducts
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/software-products'
+		}
+	}
+
+	It 'uses the device software endpoint when deviceId is supplied' {
+		$null = Get-NinjaOneSoftwareProducts -deviceId 7
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/device/7/software'
+		}
+	}
+
+	It 'delegates no-result failures to New-NinjaOneError with device id' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { $null }
+
+		{ Get-NinjaOneSoftwareProducts -deviceId 7 } | Should -Throw '*No software products found for device 7*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Get-NinjaOneSystemContacts' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith {
+			[System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+		}
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@([pscustomobject]@{ id = 9; name = 'Operations Team' })
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'uses the contacts endpoint' {
+		$null = Get-NinjaOneSystemContacts
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/contacts'
+		}
+	}
+
+	It 'delegates no-result failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { $null }
+
+		{ Get-NinjaOneSystemContacts } | Should -Throw '*No system contacts found*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}

--- a/Tests/NinjaOne.Public.Tests.ps1
+++ b/Tests/NinjaOne.Public.Tests.ps1
@@ -416,6 +416,411 @@ Describe 'Get-NinjaOneTicketBoards' {
 	}
 }
 
+Describe 'Get-NinjaOneBackupJobs' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith {
+			[System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+		}
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@([pscustomobject]@{ id = 1; status = 'COMPLETED' })
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'calls the backup jobs endpoint' {
+		$null = Get-NinjaOneBackupJobs
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq '/v2/backup/jobs'
+		}
+	}
+
+	It 'preprocesses single status into a statusFilter and calls the endpoint' {
+		$null = Get-NinjaOneBackupJobs -status 'RUNNING'
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq '/v2/backup/jobs'
+		}
+	}
+
+
+	It 'preprocesses startTimeAfter into a startTimeFilter and calls the endpoint' {
+		$null = Get-NinjaOneBackupJobs -startTimeAfter (Get-Date '2024-01-01')
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq '/v2/backup/jobs'
+		}
+	}
+
+	It 'preprocesses startTimeBetween into a startTimeFilter and calls the endpoint' {
+		$null = Get-NinjaOneBackupJobs -startTimeBetween @((Get-Date '2024-01-01'), (Get-Date '2024-01-02'))
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq '/v2/backup/jobs'
+		}
+	}
+
+	It 'delegates GET failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { throw 'backup-jobs-failed' }
+
+		{ Get-NinjaOneBackupJobs } | Should -Throw '*backup-jobs-failed*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Get-NinjaOneIntegrityCheckJobs' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith {
+			[System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+		}
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@([pscustomobject]@{ id = 1; status = 'COMPLETED' })
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'calls the integrity check jobs endpoint' {
+		$null = Get-NinjaOneIntegrityCheckJobs
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq '/v2/backup/integrity-check-jobs'
+		}
+	}
+
+	It 'preprocesses single status into a statusFilter and calls the endpoint' {
+		$null = Get-NinjaOneIntegrityCheckJobs -status 'RUNNING'
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq '/v2/backup/integrity-check-jobs'
+		}
+	}
+
+	It 'preprocesses startTimeAfter into a startTimeFilter and calls the endpoint' {
+		$null = Get-NinjaOneIntegrityCheckJobs -startTimeAfter (Get-Date '2024-01-01')
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq '/v2/backup/integrity-check-jobs'
+		}
+	}
+
+	It 'preprocesses startTimeBetween into a startTimeFilter and calls the endpoint' {
+		$null = Get-NinjaOneIntegrityCheckJobs -startTimeBetween @((Get-Date '2024-01-01'), (Get-Date '2024-01-02'))
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq '/v2/backup/integrity-check-jobs'
+		}
+	}
+
+	It 'delegates GET failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { throw 'integrity-jobs-failed' }
+
+		{ Get-NinjaOneIntegrityCheckJobs } | Should -Throw '*integrity-jobs-failed*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Get-NinjaOneTickets' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			[pscustomobject]@{ id = 1; subject = 'Test ticket' }
+		}
+		Mock -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -MockWith {
+			[pscustomobject]@{ data = @([pscustomobject]@{ id = 1; subject = 'Test ticket' }); metadata = [pscustomobject]@{ total = 1 } }
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'uses GET to the single ticket endpoint for the Single parameter set' {
+		$null = Get-NinjaOneTickets -ticketId 7
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/ticketing/ticket/7'
+		}
+	}
+
+	It 'uses POST to the board run endpoint for the Board parameter set' {
+		$null = Get-NinjaOneTickets -boardId 'board-1'
+
+		Assert-MockCalled -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/ticketing/trigger/board/board-1/run'
+		}
+	}
+
+	It 'builds board request body fields and parseDateTime when board options are supplied' {
+		$null = Get-NinjaOneTickets -boardId 'board-1' -pageSize 25 -searchCriteria 'router' -includeColumns @('subject') -lastCursorId 'cursor-1' -parseDateTime
+
+		Assert-MockCalled -CommandName New-NinjaOnePOSTRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/ticketing/trigger/board/board-1/run' -and
+			$Body.pageSize -eq 25 -and
+			$Body.searchCriteria -eq 'router' -and
+			$Body.includeColumns[0] -eq 'subject' -and
+			$Body.lastCursorId -eq 'cursor-1' -and
+			$ParseDateTime
+		}
+	}
+
+	It 'returns only the data property from Board response when includeMetadata is not set' {
+		$result = Get-NinjaOneTickets -boardId 'board-1'
+
+		$result | Should -Not -BeNullOrEmpty
+		# result should be the .data array, not the full response object
+		$result[0].id | Should -Be 1
+	}
+
+	It 'returns the full response from Board when includeMetadata is set' {
+		$result = Get-NinjaOneTickets -boardId 'board-1' -includeMetadata
+
+		$result.data | Should -Not -BeNullOrEmpty
+		$result.metadata | Should -Not -BeNullOrEmpty
+	}
+
+	It 'delegates no-result failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { $null }
+
+		{ Get-NinjaOneTickets -ticketId 7 } | Should -Throw '*No tickets found*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Get-NinjaOneRelatedItems' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith {
+			[System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+		}
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@([pscustomobject]@{ id = 1; type = 'DOCUMENT' })
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'calls v2/related-items for the all parameter set' {
+		$null = Get-NinjaOneRelatedItems -all
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/related-items'
+		}
+	}
+
+	It 'calls the entity-type route when relatedTo is used with entityType only' {
+		$null = Get-NinjaOneRelatedItems -relatedTo -entityType 'ORGANIZATION'
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/related-items/with-entity-type/ORGANIZATION'
+		}
+	}
+
+	It 'calls the entity route when relatedTo is used with entityType and entityId' {
+		$null = Get-NinjaOneRelatedItems -relatedTo -entityType 'ORGANIZATION' -entityId 5
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/related-items/with-entity/ORGANIZATION/5'
+		}
+	}
+
+	It 'calls the related-entity-type route when relatedFrom is used with entityType only' {
+		$null = Get-NinjaOneRelatedItems -relatedFrom -entityType 'ORGANIZATION'
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/related-items/with-related-entity-type/ORGANIZATION'
+		}
+	}
+
+	It 'calls the related-entity route when relatedFrom is used with entityType and entityId' {
+		$null = Get-NinjaOneRelatedItems -relatedFrom -entityType 'ORGANIZATION' -entityId 5
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/related-items/with-related-entity/ORGANIZATION/5'
+		}
+	}
+
+	It 'delegates no-result failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { $null }
+
+		{ Get-NinjaOneRelatedItems -all } | Should -Throw '*No related items found*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Get-NinjaOneOrganisationDocuments' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith {
+			[System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+		}
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@([pscustomobject]@{ id = 1; name = 'Doc 1' })
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'calls the single-organisation documents endpoint when organisationId is supplied' {
+		$null = Get-NinjaOneOrganisationDocuments -organisationId 12
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/organization/12/documents'
+		}
+	}
+
+	It 'calls the all-organisations documents endpoint when no organisationId is supplied' {
+		$null = Get-NinjaOneOrganisationDocuments
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/organization/documents'
+		}
+	}
+
+	It 'delegates no-result failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { $null }
+
+		{ Get-NinjaOneOrganisationDocuments -organisationId 12 } | Should -Throw '*No documents found*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Get-NinjaOneTicketingUsers' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith {
+			[System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+		}
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@([pscustomobject]@{ id = 1; name = 'Alice Tech' })
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'calls the ticketing users endpoint' {
+		$null = Get-NinjaOneTicketingUsers
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/ticketing/app-user-contact'
+		}
+	}
+
+	It 'passes userType as a query parameter' {
+		$null = Get-NinjaOneTicketingUsers -userType 'TECHNICIAN'
+
+		Assert-MockCalled -CommandName New-NinjaOneQuery -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Parameters.ContainsKey('userType')
+		}
+	}
+
+	It 'delegates no-result failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { $null }
+
+		{ Get-NinjaOneTicketingUsers } | Should -Throw '*No ticketing users found*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Get-NinjaOneDeviceOSPatchInstalls' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith {
+			[System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+		}
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@([pscustomobject]@{ patchId = 42; status = 'INSTALLED' })
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'calls the device OS patch installs endpoint for the supplied device id' {
+		$null = Get-NinjaOneDeviceOSPatchInstalls -deviceId 77
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/device/77/os-patch-installs'
+		}
+	}
+
+	It 'converts installedAfter DateTime to epoch and calls the endpoint' {
+		$null = Get-NinjaOneDeviceOSPatchInstalls -deviceId 77 -installedAfter (Get-Date '2024-01-01')
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/device/77/os-patch-installs'
+		}
+	}
+
+	It 'accepts installedAfterUnixEpoch and calls the endpoint' {
+		$null = Get-NinjaOneDeviceOSPatchInstalls -deviceId 77 -installedAfterUnixEpoch 1704067200
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/device/77/os-patch-installs'
+		}
+	}
+
+	It 'delegates GET failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { throw 'os-patch-installs-failed' }
+
+		{ Get-NinjaOneDeviceOSPatchInstalls -deviceId 77 } | Should -Throw '*os-patch-installs-failed*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
+Describe 'Get-NinjaOneDeviceSoftwarePatchInstalls' {
+	BeforeEach {
+		Mock -CommandName New-NinjaOneQuery -ModuleName $ModuleName -MockWith {
+			[System.Web.HttpUtility]::ParseQueryString([String]::Empty)
+		}
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
+			@([pscustomobject]@{ patchId = 99; status = 'INSTALLED' })
+		}
+		Mock -CommandName New-NinjaOneError -ModuleName $ModuleName -MockWith {
+			param($ErrorRecord)
+			throw $ErrorRecord.Exception
+		}
+	}
+
+	It 'calls the device software patch installs endpoint for the supplied device id' {
+		$null = Get-NinjaOneDeviceSoftwarePatchInstalls -deviceId 33
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/device/33/software-patch-installs'
+		}
+	}
+
+	It 'converts installedAfter DateTime to epoch and calls the endpoint' {
+		$null = Get-NinjaOneDeviceSoftwarePatchInstalls -deviceId 33 -installedAfter (Get-Date '2024-01-01')
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/device/33/software-patch-installs'
+		}
+	}
+
+	It 'accepts installedBeforeUnixEpoch and calls the endpoint' {
+		$null = Get-NinjaOneDeviceSoftwarePatchInstalls -deviceId 33 -installedBeforeUnixEpoch 1704153600
+
+		Assert-MockCalled -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -Times 1 -ParameterFilter {
+			$Resource -eq 'v2/device/33/software-patch-installs'
+		}
+	}
+
+	It 'delegates GET failures to New-NinjaOneError' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { throw 'sw-patch-installs-failed' }
+
+		{ Get-NinjaOneDeviceSoftwarePatchInstalls -deviceId 33 } | Should -Throw '*sw-patch-installs-failed*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+}
+
 Get-Module -Name $ModuleName | Remove-Module -Force -ErrorAction SilentlyContinue
 Import-Module $ModulePath -Force
 

--- a/Tests/NinjaOne.Schema.Tests.ps1
+++ b/Tests/NinjaOne.Schema.Tests.ps1
@@ -20,13 +20,21 @@ Describe ('<ModuleName> - Schema Completeness') -Tags 'Module' {
 	Context 'Function <_.Name>' -ForEach $FunctionList {
 		$AST = $_.ScriptBlock.Ast
 		$MetadataElement = Get-MetadataElement -AST $AST
-	$HasMetadata = $MetadataElement -and @($MetadataElement).Count -gt 0
+		$HasMetadata = $MetadataElement -and @($MetadataElement).Count -gt 0
 		$PositionalArguments = @()
 		$Metadata = @()
 		
 		if ($HasMetadata) {
 			$PositionalArguments = @(Get-PositionalArguments -MetadataElement $MetadataElement)
 			$Metadata = @(Get-Metadata -PositionalArguments $PositionalArguments)
+		}
+
+		It ('should not contain duplicate metadata pairs') -Skip:($Metadata.Count -eq 0) {
+			$DuplicatePairs = $Metadata |
+			Group-Object -Property { '{0}:{1}' -f $_.Method, $_.Endpoint } |
+			Where-Object Count -GT 1
+
+			$DuplicatePairs | Should -BeNullOrEmpty -Because 'Duplicate metadata pairs can hide endpoint drift and make endpoint ownership ambiguous.'
 		}
 		
 		Context 'Metadata Attribute <_>' -ForEach $MetadataElement -Skip:(-not $HasMetadata) {
@@ -57,10 +65,25 @@ Describe ('<ModuleName> - Schema Completeness') -Tags 'Module' {
 		}
 		
 		Context 'Metadata Pair <Method>: <Endpoint>' -ForEach $Metadata -Skip:($Metadata.Count -eq 0) {
+			It ('should use a supported HTTP method') {
+				$PSItem.Method | Should -BeIn @('get', 'post', 'patch', 'put', 'delete', 'options', 'head')
+			}
+
 			It ('should match an endpoint') {
 				$MetadataItem = $_
 				$MatchedEndpoint = $Endpoints | Where-Object { $_.Path -eq $MetadataItem.Endpoint -and $_.Method -eq $MetadataItem.Method }
 				$MatchedEndpoint | Should -Not -BeNullOrEmpty -Because ('{0}: {1} should match an endpoint' -f $MetadataItem.Method, $MetadataItem.Endpoint)
+			}
+
+			It ('should match an endpoint template ignoring placeholder names') {
+				$MetadataItem = $_
+				$MetadataTemplate = [regex]::Replace([string]$MetadataItem.Endpoint, '\{[^/]+\}', '{}')
+				$MatchedEndpoint = $Endpoints | Where-Object {
+					$EndpointTemplate = [regex]::Replace([string]$PSItem.Path, '\{[^/]+\}', '{}')
+					$EndpointTemplate -eq $MetadataTemplate -and $PSItem.Method -eq $MetadataItem.Method
+				}
+
+				$MatchedEndpoint | Should -Not -BeNullOrEmpty -Because ('{0}: {1} should match an endpoint template after placeholder normalization' -f $MetadataItem.Method, $MetadataItem.Endpoint)
 			}
 		}
 	}
@@ -75,6 +98,17 @@ Describe ('<ModuleName> - Schema Completeness') -Tags 'Module' {
 			$CurrentEndpoint = $_
 			$MetadataPair = $AllMetadata | Where-Object { $_.Endpoint -eq $CurrentEndpoint.Path -and $_.Method -eq $CurrentEndpoint.Method } 
 			$MetadataPair | Should -Not -BeNullOrEmpty -Because ('{0}: {1} should match a metadata attribute' -f $CurrentEndpoint.Method, $CurrentEndpoint.Path)
+		}
+
+		It ('should match a metadata attribute template ignoring placeholder names') {
+			$CurrentEndpoint = $_
+			$EndpointTemplate = [regex]::Replace([string]$CurrentEndpoint.Path, '\{[^/]+\}', '{}')
+			$MetadataPair = $AllMetadata | Where-Object {
+				$MetadataTemplate = [regex]::Replace([string]$PSItem.Endpoint, '\{[^/]+\}', '{}')
+				$MetadataTemplate -eq $EndpointTemplate -and $PSItem.Method -eq $CurrentEndpoint.Method
+			}
+
+			$MetadataPair | Should -Not -BeNullOrEmpty -Because ('{0}: {1} should match a metadata attribute template after placeholder normalization' -f $CurrentEndpoint.Method, $CurrentEndpoint.Path)
 		}
 	}
 }

--- a/docs/NinjaOne/development/index.mdx
+++ b/docs/NinjaOne/development/index.mdx
@@ -218,6 +218,7 @@ Additional development pages are handled by the Docusaurus sidebar, including:
 
 - `Quality Gates & Code Standards`
 - `Help Generation Deep Dive`
+- `Test Coverage Enhancement Plan`
 - `Styling & Conventions`
 - `Troubleshooting Guide`
 - `Delivery & Release Process`

--- a/docs/NinjaOne/development/test-coverage-enhancement-plan.mdx
+++ b/docs/NinjaOne/development/test-coverage-enhancement-plan.mdx
@@ -1,0 +1,81 @@
+---
+title: Test Coverage Enhancement Plan
+sidebar_position: 8
+---
+
+This page tracks the current incremental test-coverage plan, ordered by impact and risk.
+
+## Goals
+
+- Increase line and branch coverage without broad refactors.
+- Prioritize high-reuse private helpers before adding many public wrappers.
+- Keep tests deterministic and cross-platform safe.
+
+## Current Priority Order
+
+1. Private request and error helpers
+2. Public cmdlet endpoint/resource mapping tests
+3. Low-risk class constructor/property coverage
+4. Broader folder-by-folder public coverage expansion
+
+## Batch 1 (Started)
+
+Focus:
+- `New-NinjaOnePOSTRequest`
+- `New-NinjaOneError`
+- `Get-NinjaOneUsers`
+
+Implemented in this batch:
+- Added additional `New-NinjaOnePOSTRequest` tests for endpoint preflight behavior.
+- Added `Get-NinjaOneUsers` tests for default/organisation resource routing and no-result error delegation.
+
+## Next Batches
+
+### Batch 2
+
+Targets:
+- `Source/Private/New-NinjaOneQuery.ps1`
+- `Source/Private/Get-NinjaOneSecrets.ps1`
+
+Test themes:
+- query-string composition edge cases
+- secret fallback and incomplete secret set handling
+
+### Batch 3
+
+Targets:
+- `Source/Public/System/Get/Get-NinjaOneAlerts.ps1`
+- `Source/Public/System/Get/Get-NinjaOneJobs.ps1`
+- `Source/Public/Queries/Get/Get-NinjaOneSoftwareInventory.ps1`
+
+Test themes:
+- resource selection
+- query propagation
+- null/empty result handling through `New-NinjaOneError`
+
+### Batch 4
+
+Targets:
+- `Source/Classes/06-NinjaOneTicketBoardSort.Object.Class.ps1`
+
+Test themes:
+- constructor defaults
+- expected property mapping
+
+## Validation Workflow Per Batch
+
+Run these checks after each test batch:
+
+```powershell
+pwsh -File .\DevOps\Quality\test.ps1 -Suite private,public -skipScriptAnalyzer
+pwsh -File .\DevOps\Quality\run-pssa.ps1
+```
+
+Then review updated coverage artifacts under `.artifacts`:
+- `CodeCoverage.private.xml`
+- `CodeCoverage.public.xml`
+
+## Notes
+
+- Prefer deterministic mocks over network/listener behavior in private tests.
+- Add behavior assertions (resource path, query/body shape, error delegation) before adding broad existence-only tests.


### PR DESCRIPTION
This pull request introduces significant improvements to test coverage reporting, CI documentation, and internal API request handling. It standardizes how coverage is measured and reported, adds new VS Code tasks for developer workflows, enforces minimum coverage thresholds in CI, and refactors internal query string handling for API requests to use a more robust type.

**Test Coverage & Quality Reporting Improvements:**

* Added new scripts (`show-coverage.ps1`, `run-public-suite-tail.ps1`) to standardize coverage reporting and test suite tailing, and integrated them as VS Code tasks for easier access. (`DevOps/Quality/show-coverage.ps1`, `DevOps/Quality/run-public-suite-tail.ps1`, `.vscode/tasks.json`, [[1]](diffhunk://#diff-9e6acb93c0e3f9d0d01f6f9f21539247f3a59921514b39e35330f9ea28cff788R1-R78) [[2]](diffhunk://#diff-c33c081308e3c683a2e1340f43c09b8ba4e421a6f02c4e4b4f59759d075d2bdcR1-R24) [[3]](diffhunk://#diff-7d76d7533653c23b753fc7ce638cf64bdb5e419927d276af836d3a03fdf1745aR56-R100)
* Updated documentation to instruct contributors to use repository scripts/tasks as the single source of truth for coverage and quality reporting, discouraging ad-hoc commands. (`.github/copilot-instructions.md`, [.github/copilot-instructions.mdR21-R30](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R21-R30))
* Enforced minimum line coverage thresholds per suite in `test.ps1`, causing CI to fail if coverage drops below configured levels and reporting readiness for the next 5% coverage target. (`DevOps/Quality/test.ps1`, [[1]](diffhunk://#diff-da514c402327250343c6583221d229590aa413e13a243b47291e899e406818d8R10-R15) [[2]](diffhunk://#diff-da514c402327250343c6583221d229590aa413e13a243b47291e899e406818d8R169-R244)

**CI/CD Pipeline & Workflow Enhancements:**

* Updated CI workflow to include publishing development docs artifacts and adjusted the docs sync workflow to download artifacts instead of checking out the repo, improving reliability and efficiency. (`.github/workflows/ci.yml`, `.github/workflows/sync-development-docs.yml`, [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL362-R362) [[2]](diffhunk://#diff-24d7cfb8fa521c781db1a9fc858f9df1d902e636e061bf732b8c02811c1a1feaL26-R32) [[3]](diffhunk://#diff-24d7cfb8fa521c781db1a9fc858f9df1d902e636e061bf732b8c02811c1a1feaL39-R51)

**Internal API Request Handling Refactor:**

* Refactored all internal API request functions (`New-NinjaOneGETRequest`, `New-NinjaOnePOSTRequest`, `New-NinjaOnePUTRequest`, `New-NinjaOnePATCHRequest`, `New-NinjaOneQuery`) to use `NameValueCollection` for query string parameters instead of hashtables, simplifying code and improving type safety. (`Source/Private/New-NinjaOneGETRequest.ps1`, `Source/Private/New-NinjaOnePOSTRequest.ps1`, `Source/Private/New-NinjaOnePUTRequest.ps1`, `Source/Private/New-NinjaOnePATCHRequest.ps1`, `Source/Private/New-NinjaOneQuery.ps1`, [[1]](diffhunk://#diff-09beb307c413345bc0a182e6a8accf406f77a358aa856aeeac3b5a806fd62cc7L21-R22) [[2]](diffhunk://#diff-09beb307c413345bc0a182e6a8accf406f77a358aa856aeeac3b5a806fd62cc7L38-R38) [[3]](diffhunk://#diff-ad3823f4328c0f1ef758f01b657f06ea0c7002ea4d7bb5e88afa893c2f7ac119L22-R23) [[4]](diffhunk://#diff-ad3823f4328c0f1ef758f01b657f06ea0c7002ea4d7bb5e88afa893c2f7ac119L251-R251) [[5]](diffhunk://#diff-b15ee087bbf9a375702994541b6ce2cab7031daec0fed0face5f32534fe3aca4L19-R20) [[6]](diffhunk://#diff-b15ee087bbf9a375702994541b6ce2cab7031daec0fed0face5f32534fe3aca4L39-R39) [[7]](diffhunk://#diff-b15ee087bbf9a375702994541b6ce2cab7031daec0fed0face5f32534fe3aca4L53-R49) [[8]](diffhunk://#diff-265f0e4de2df5739651ea9c835a6ca1e7692e260b670393c9cf6eb49c99ed1f8L21-R22) [[9]](diffhunk://#diff-265f0e4de2df5739651ea9c835a6ca1e7692e260b670393c9cf6eb49c99ed1f8L39-R39) [[10]](diffhunk://#diff-265f0e4de2df5739651ea9c835a6ca1e7692e260b670393c9cf6eb49c99ed1f8L53-R49) [[11]](diffhunk://#diff-1dd201419ee26a84787f611516dd085c875ba840d290a1b235244d32ff95597eL36-R36)

**VS Code & Command Approval Improvements:**

* Added approval-friendly commands and coverage utilities to the workspace settings to streamline code review and command approval processes. (`NinjaOne.code-workspace`, [NinjaOne.code-workspaceR114-R118](diffhunk://#diff-0888e7e7c10fb3943969954befa1aacaad66c1eb920bbee807ce6aab77f48c0dR114-R118))

These changes collectively improve the reliability, transparency, and maintainability of test coverage reporting and internal development workflows.