### PR TITLE
Fix repository reference in documentation sync workflow

### DIFF
--- a/.github/workflows/sync-development-docs.yml
+++ b/.github/workflows/sync-development-docs.yml
@@ -29,7 +29,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           $ErrorActionPreference = 'Stop'
-          gh run download ${{ github.event.workflow_run.id }} --name module-docs --dir docs-artifact
+          gh run download ${{ github.event.workflow_run.id }} --name module-docs --dir docs-artifact --repo homotechsual/NinjaOne
 
       - name: Clone and update homotechsualdocs
         shell: pwsh


### PR DESCRIPTION
This pull request makes a small update to the `.github/workflows/sync-development-docs.yml` workflow. The change ensures that the `gh run download` command explicitly specifies the `homotechsual/NinjaOne` repository when downloading the `module-docs` artifact.