### PR TITLE
Centralize request preflight and update version to 2.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Please note that backwards compatibility breaks are prefixed with `{"BC"}` (shor
 
 Note: Version 2.3.0 was released in error and will be skipped.
 
+## 2026-08-05 - Version 2.8.1
+
+* Updates:
+  * Centralize connection and authentication preflight checks in the shared request path (`Invoke-NinjaOneRequest`) so request wrappers fail consistently when not connected.
+
+* Fixes:
+  * Stop masking upstream request failures as "No ... found" in system GET cmdlets, so authentication and request errors surface with their real cause.
+  * Add regression coverage for shared request preflight enforcement and the updated upstream error delegation behavior.
+
 ## 2026-07-23 - Version 2.8.0
 
 * Updates:

--- a/Source/NinjaOne.psd1
+++ b/Source/NinjaOne.psd1
@@ -12,7 +12,7 @@
 	RootModule = '.\NinjaOne.psm1'
 
 	# Version number of this module.
-	ModuleVersion = '2.8.0'
+	ModuleVersion = '2.8.1'
 
 	# Supported PSEditions
 	# CompatiblePSEditions = @()

--- a/Source/Private/Invoke-NinjaOnePreFlightCheck.ps1
+++ b/Source/Private/Invoke-NinjaOnePreFlightCheck.ps1
@@ -34,6 +34,11 @@ function Invoke-NinjaOnePreFlightCheck {
 			$ErrorRecord = [ErrorRecord]::New($NoAuthTokenException, 'NoAuthToken', 'AuthenticationError', 'NinjaOnePreFlightCheck')
 			$PSCmdlet.throwTerminatingError($ErrorRecord)
 		}
+		if ([String]::IsNullOrWhiteSpace([String]$Script:NRAPIAuthenticationInformation.Access)) {
+			$NoAuthTokenException = [System.Exception]::New("Missing NinjaOne authentication token, please run 'Connect-NinjaOne' first.")
+			$ErrorRecord = [ErrorRecord]::New($NoAuthTokenException, 'NoAuthToken', 'AuthenticationError', 'NinjaOnePreFlightCheck')
+			$PSCmdlet.throwTerminatingError($ErrorRecord)
+		}
 	} else {
 		Write-Verbose 'Skipping connection checks.'
 	}

--- a/Source/Private/Invoke-NinjaOnePreFlightCheck.ps1
+++ b/Source/Private/Invoke-NinjaOnePreFlightCheck.ps1
@@ -29,7 +29,7 @@ function Invoke-NinjaOnePreFlightCheck {
 			$ErrorRecord = [ErrorRecord]::New($NoConnectionInformationException, 'NoConnectionInformation', 'AuthenticationError', 'NinjaOnePreFlightCheck')
 			$PSCmdlet.throwTerminatingError($ErrorRecord)
 		}
-		if (($null -eq $Script:NRAPIAuthToken) -and ($null -eq $AllowAnonymous)) {
+		if ($null -eq $Script:NRAPIAuthenticationInformation) {
 			$NoAuthTokenException = [System.Exception]::New("Missing NinjaOne authentication token, please run 'Connect-NinjaOne' first.")
 			$ErrorRecord = [ErrorRecord]::New($NoAuthTokenException, 'NoAuthToken', 'AuthenticationError', 'NinjaOnePreFlightCheck')
 			$PSCmdlet.throwTerminatingError($ErrorRecord)

--- a/Source/Public/PSModule/Invoke/Invoke-NinjaOneRequest.ps1
+++ b/Source/Public/PSModule/Invoke/Invoke-NinjaOneRequest.ps1
@@ -50,7 +50,8 @@ function Invoke-NinjaOneRequest {
 	begin {
 		Invoke-NinjaOnePreFlightCheck
 		$Now = Get-Date
-		if ($Script:NRAPIAuthenticationInformation.Expires -le $Now) {
+		$TokenExpiry = $Script:NRAPIAuthenticationInformation.Expires
+		if (($TokenExpiry -is [DateTime]) -and ($TokenExpiry -le $Now)) {
 			Write-Verbose 'The auth token has expired, renewing.'
 			Update-NinjaOneToken -Verbose:$VerbosePreference
 		}

--- a/Source/Public/PSModule/Invoke/Invoke-NinjaOneRequest.ps1
+++ b/Source/Public/PSModule/Invoke/Invoke-NinjaOneRequest.ps1
@@ -48,12 +48,7 @@ function Invoke-NinjaOneRequest {
 
 	)
 	begin {
-		if ($null -eq $Script:NRAPIConnectionInformation) {
-			throw "Missing NinjaOne connection information, please run 'Connect-NinjaOne' first."
-		}
-		if ($null -eq $Script:NRAPIAuthenticationInformation) {
-			throw "Missing NinjaOne authentication tokens, please run 'Connect-NinjaOne' first."
-		}
+		Invoke-NinjaOnePreFlightCheck
 		$Now = Get-Date
 		if ($Script:NRAPIAuthenticationInformation.Expires -le $Now) {
 			Write-Verbose 'The auth token has expired, renewing.'

--- a/Source/Public/System/Get/Get-NinjaOneAlerts.ps1
+++ b/Source/Public/System/Get/Get-NinjaOneAlerts.ps1
@@ -83,18 +83,15 @@ function Get-NinjaOneAlerts {
 			if ($parseDateTime) {
 				$RequestParams.ParseDateTime = $parseDateTime
 			}
-			try {
-				$AlertResults = New-NinjaOneGETRequest @RequestParams
-				return $AlertResults
-			} catch {
-				if (-not $AlertResults) {
-					if ($deviceId) {
-						throw ('No alerts found for device {0}.' -f $deviceId)
-					} else {
-						throw 'No alerts found.'
-					}
+			$AlertResults = New-NinjaOneGETRequest @RequestParams
+			if (-not $AlertResults) {
+				if ($deviceId) {
+					throw ('No alerts found for device {0}.' -f $deviceId)
+				} else {
+					throw 'No alerts found.'
 				}
 			}
+			return $AlertResults
 		} catch {
 			New-NinjaOneError -ErrorRecord $_
 		}

--- a/Source/Public/System/Get/Get-NinjaOneAutomations.ps1
+++ b/Source/Public/System/Get/Get-NinjaOneAutomations.ps1
@@ -48,14 +48,11 @@ function Get-NinjaOneAutomations {
 				Resource = $Resource
 				QSCollection = $QSCollection
 			}
-			try {
-				$AutomationResults = New-NinjaOneGETRequest @RequestParams
-				return $AutomationResults
-			} catch {
-				if (-not $AutomationResults) {
-					throw 'No automation scripts found.'
-				}
+			$AutomationResults = New-NinjaOneGETRequest @RequestParams
+			if (-not $AutomationResults) {
+				throw 'No automation scripts found.'
 			}
+			return $AutomationResults
 		} catch {
 			New-NinjaOneError -ErrorRecord $_
 		}

--- a/Source/Public/System/Get/Get-NinjaOneDevices.ps1
+++ b/Source/Public/System/Get/Get-NinjaOneDevices.ps1
@@ -144,18 +144,15 @@ function Get-NinjaOneDevices {
 			if ($parseDateTime) {
 				$RequestParams.ParseDateTime = $parseDateTime
 			}
-			try {
-				$DeviceResults = New-NinjaOneGETRequest @RequestParams
-				return $DeviceResults
-			} catch {
-				if (-not $DeviceResults) {
-					if ($deviceId) {
-						throw ('Device with id {0} not found.' -f $deviceId)
-					} else {
-						throw 'No devices found.'
-					}
+			$DeviceResults = New-NinjaOneGETRequest @RequestParams
+			if (-not $DeviceResults) {
+				if ($deviceId) {
+					throw ('Device with id {0} not found.' -f $deviceId)
+				} else {
+					throw 'No devices found.'
 				}
 			}
+			return $DeviceResults
 		} catch {
 			New-NinjaOneError -ErrorRecord $_
 		}

--- a/Source/Public/System/Get/Get-NinjaOneNotificationChannels.ps1
+++ b/Source/Public/System/Get/Get-NinjaOneNotificationChannels.ps1
@@ -53,14 +53,11 @@ function Get-NinjaOneNotificationChannels {
 				Resource = $Resource
 				QSCollection = $QSCollection
 			}
-			try {
-				$NotificationChannelResults = New-NinjaOneGETRequest @RequestParams
-				return $NotificationChannelResults
-			} catch {
-				if (-not $NotificationChannelResults) {
-					throw 'No notification channels found.'
-				}
+			$NotificationChannelResults = New-NinjaOneGETRequest @RequestParams
+			if (-not $NotificationChannelResults) {
+				throw 'No notification channels found.'
 			}
+			return $NotificationChannelResults
 		} catch {
 			New-NinjaOneError -ErrorRecord $_
 		}

--- a/Source/Public/System/Get/Get-NinjaOneOrganisations.ps1
+++ b/Source/Public/System/Get/Get-NinjaOneOrganisations.ps1
@@ -93,18 +93,15 @@ function Get-NinjaOneOrganisations {
 					QSCollection = $QSCollection
 				}
 			}
-			try {
-				$OrganisationResults = New-NinjaOneGETRequest @RequestParams
-				return $OrganisationResults
-			} catch {
-				if (-not $OrganisationResults) {
-					if ($organisationId) {
-						throw ('Organisation with id {0} not found.' -f $organisationId)
-					} else {
-						throw 'No organisations found.'
-					}
+			$OrganisationResults = New-NinjaOneGETRequest @RequestParams
+			if (-not $OrganisationResults) {
+				if ($organisationId) {
+					throw ('Organisation with id {0} not found.' -f $organisationId)
+				} else {
+					throw 'No organisations found.'
 				}
 			}
+			return $OrganisationResults
 		} catch {
 			New-NinjaOneError -ErrorRecord $_
 		}

--- a/Tests/NinjaOne.Private.Tests.ps1
+++ b/Tests/NinjaOne.Private.Tests.ps1
@@ -3051,7 +3051,7 @@ Describe 'Invoke-NinjaOnePreFlightCheck' {
 			$module = Get-Module -Name $ModuleName
 			& $module {
 				$script:NRAPIConnectionInformation = @{ URL = 'https://test.com' }
-				$script:NRAPIAuthToken = 'test-token'
+				$script:NRAPIAuthenticationInformation = @{ Access = 'test-token' }
 				{ Invoke-NinjaOnePreFlightCheck } | Should -Not -Throw
 			}
 		}
@@ -3068,7 +3068,7 @@ Describe 'Invoke-NinjaOnePreFlightCheck' {
 			$module = Get-Module -Name $ModuleName
 			& $module {
 				$script:NRAPIConnectionInformation = @{ URL = 'https://test.com' }
-				$script:NRAPIAuthToken = 'test-token'
+				$script:NRAPIAuthenticationInformation = @{ Access = 'test-token' }
 				{ Invoke-NinjaOnePreFlightCheck } | Should -Not -Throw
 			}
 		}
@@ -3077,8 +3077,7 @@ Describe 'Invoke-NinjaOnePreFlightCheck' {
 			$module = Get-Module -Name $ModuleName
 			& $module {
 				$script:NRAPIConnectionInformation = @{ URL = 'https://test.com' }
-				$script:NRAPIAuthToken = $null
-				$script:AllowAnonymous = $null
+				$script:NRAPIAuthenticationInformation = $null
 				{ Invoke-NinjaOnePreFlightCheck } | Should -Throw
 			}
 		}
@@ -3091,7 +3090,7 @@ Describe 'Invoke-NinjaOnePreFlightCheck' {
 					Instance = 'test.ninjaone.com'
 					AuthMode = 'OAuth'
 				}
-				$script:NRAPIAuthToken = 'test-token'
+				$script:NRAPIAuthenticationInformation = @{ Access = 'test-token' }
 				{ Invoke-NinjaOnePreFlightCheck } | Should -Not -Throw
 			}
 		}
@@ -3100,8 +3099,7 @@ Describe 'Invoke-NinjaOnePreFlightCheck' {
 			$module = Get-Module -Name $ModuleName
 			& $module {
 				$script:NRAPIConnectionInformation = @{ URL = 'https://test.com' }
-				$script:NRAPIAuthToken = $null
-				$script:AllowAnonymous = $null
+				$script:NRAPIAuthenticationInformation = $null
 				{ Invoke-NinjaOnePreFlightCheck } | Should -Throw
 			}
 		}
@@ -3110,9 +3108,54 @@ Describe 'Invoke-NinjaOnePreFlightCheck' {
 			$module = Get-Module -Name $ModuleName
 			& $module {
 				$script:NRAPIConnectionInformation = $null
-				$script:NRAPIAuthToken = $null
+				$script:NRAPIAuthenticationInformation = $null
 				{ Invoke-NinjaOnePreFlightCheck -SkipConnectionChecks } | Should -Not -Throw
 			}
+		}
+	}
+}
+
+Describe 'Invoke-NinjaOneRequest' {
+	Context 'Preflight enforcement' {
+		It 'should invoke the shared preflight check before making a request' {
+			Mock -CommandName Invoke-NinjaOnePreFlightCheck -ModuleName $ModuleName -MockWith {}
+			Mock -CommandName Invoke-WebRequest -ModuleName $ModuleName -MockWith {
+				[pscustomobject]@{
+					StatusCode = 200
+					Content = '{"result":{}}'
+					Headers = @{}
+				}
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$script:NRAPIConnectionInformation = @{ URL = 'https://test.com' }
+				$script:NRAPIAuthenticationInformation = @{
+					Type = 'Bearer'
+					Access = 'test-token'
+					Expires = (Get-Date).AddMinutes(30)
+				}
+
+				$null = Invoke-NinjaOneRequest -Method 'GET' -Uri 'https://test.com/v2/test'
+			}
+
+			Assert-MockCalled -CommandName Invoke-NinjaOnePreFlightCheck -ModuleName $ModuleName -Times 1
+		}
+
+		It 'should stop before request execution when preflight fails' {
+			Mock -CommandName Invoke-NinjaOnePreFlightCheck -ModuleName $ModuleName -MockWith {
+				throw [System.Exception]::new('preflight failure')
+			}
+			Mock -CommandName Invoke-WebRequest -ModuleName $ModuleName -MockWith {
+				throw [System.Exception]::new('request should not run')
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				{ Invoke-NinjaOneRequest -Method 'GET' -Uri 'https://test.com/v2/test' } | Should -Throw '*preflight failure*'
+			}
+
+			Assert-MockCalled -CommandName Invoke-WebRequest -ModuleName $ModuleName -Times 0
 		}
 	}
 }

--- a/Tests/NinjaOne.Private.Tests.ps1
+++ b/Tests/NinjaOne.Private.Tests.ps1
@@ -3082,6 +3082,24 @@ Describe 'Invoke-NinjaOnePreFlightCheck' {
 			}
 		}
 
+		It 'should throw when authentication information does not include an access token' {
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$script:NRAPIConnectionInformation = @{ URL = 'https://test.com' }
+				$script:NRAPIAuthenticationInformation = @{}
+				{ Invoke-NinjaOnePreFlightCheck } | Should -Throw '*Missing NinjaOne authentication token*'
+			}
+		}
+
+		It 'should throw when authentication access token is empty' {
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$script:NRAPIConnectionInformation = @{ URL = 'https://test.com' }
+				$script:NRAPIAuthenticationInformation = @{ Access = '' }
+				{ Invoke-NinjaOnePreFlightCheck } | Should -Throw '*Missing NinjaOne authentication token*'
+			}
+		}
+
 		It 'should validate all required connection fields' {
 			$module = Get-Module -Name $ModuleName
 			& $module {

--- a/Tests/NinjaOne.Private.Tests.ps1
+++ b/Tests/NinjaOne.Private.Tests.ps1
@@ -3175,6 +3175,33 @@ Describe 'Invoke-NinjaOneRequest' {
 
 			Assert-MockCalled -CommandName Invoke-WebRequest -ModuleName $ModuleName -Times 0
 		}
+
+		It 'should not refresh token when expiry is missing' {
+			Mock -CommandName Invoke-NinjaOnePreFlightCheck -ModuleName $ModuleName -MockWith {}
+			Mock -CommandName Update-NinjaOneToken -ModuleName $ModuleName -MockWith {
+				throw [System.Exception]::new('refresh should not run')
+			}
+			Mock -CommandName Invoke-WebRequest -ModuleName $ModuleName -MockWith {
+				[pscustomobject]@{
+					StatusCode = 200
+					Content = '{"result":{}}'
+					Headers = @{}
+				}
+			}
+
+			$module = Get-Module -Name $ModuleName
+			& $module {
+				$script:NRAPIConnectionInformation = @{ URL = 'https://test.com' }
+				$script:NRAPIAuthenticationInformation = @{
+					Type = 'Bearer'
+					Access = 'test-token'
+				}
+
+				{ Invoke-NinjaOneRequest -Method 'GET' -Uri 'https://test.com/v2/test' } | Should -Not -Throw
+			}
+
+			Assert-MockCalled -CommandName Update-NinjaOneToken -ModuleName $ModuleName -Times 0
+		}
 	}
 }
 

--- a/Tests/NinjaOne.Public.Tests.ps1
+++ b/Tests/NinjaOne.Public.Tests.ps1
@@ -2693,18 +2693,18 @@ Describe 'Get-NinjaOneAlerts' {
 		}
 	}
 
-	It 'delegates no-result global failures to New-NinjaOneError' {
+	It 'delegates upstream global request failures to New-NinjaOneError without masking' {
 		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { throw 'Not found' }
 
-		{ Get-NinjaOneAlerts } | Should -Throw '*No alerts found*'
+		{ Get-NinjaOneAlerts } | Should -Throw '*Not found*'
 
 		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
 	}
 
-	It 'delegates no-result device failures to New-NinjaOneError with device id' {
+	It 'delegates upstream device request failures to New-NinjaOneError without masking' {
 		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { throw 'Not found' }
 
-		{ Get-NinjaOneAlerts -deviceId 7 } | Should -Throw '*No alerts found for device 7*'
+		{ Get-NinjaOneAlerts -deviceId 7 } | Should -Throw '*Not found*'
 
 		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
 	}
@@ -2894,12 +2894,12 @@ Describe 'Get-NinjaOneOrganisations' {
 		}
 	}
 
-	It 'normalizes upstream request failures to a no-organisations error via New-NinjaOneError' {
+	It 'delegates upstream request failures to New-NinjaOneError without masking' {
 		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
 			throw 'request-failed'
 		}
 
-		{ Get-NinjaOneOrganisations } | Should -Throw '*No organisations found*'
+		{ Get-NinjaOneOrganisations } | Should -Throw '*request-failed*'
 		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
 	}
 }
@@ -3002,12 +3002,12 @@ Describe 'Get-NinjaOneDevices' {
 		}
 	}
 
-	It 'normalizes upstream request failures to a not-found device error via New-NinjaOneError' {
+	It 'delegates upstream request failures to New-NinjaOneError without masking' {
 		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith {
 			throw 'request-failed'
 		}
 
-		{ Get-NinjaOneDevices -deviceId 7 } | Should -Throw '*Device with id 7 not found*'
+		{ Get-NinjaOneDevices -deviceId 7 } | Should -Throw '*request-failed*'
 		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
 	}
 }
@@ -3172,7 +3172,7 @@ Describe 'Get-NinjaOneNotificationChannels' {
 			throw 'notification-request-failed'
 		}
 
-		{ Get-NinjaOneNotificationChannels } | Should -Throw '*No notification channels found*'
+		{ Get-NinjaOneNotificationChannels } | Should -Throw '*notification-request-failed*'
 		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
 	}
 }
@@ -3212,7 +3212,7 @@ Describe 'Get-NinjaOneAutomations' {
 			throw 'automation-request-failed'
 		}
 
-		{ Get-NinjaOneAutomations } | Should -Throw '*No automation scripts found*'
+		{ Get-NinjaOneAutomations } | Should -Throw '*automation-request-failed*'
 		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
 	}
 }

--- a/Tests/NinjaOne.Public.Tests.ps1
+++ b/Tests/NinjaOne.Public.Tests.ps1
@@ -2693,6 +2693,20 @@ Describe 'Get-NinjaOneAlerts' {
 		}
 	}
 
+	It 'throws no-result global errors when the API returns null' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { $null }
+
+		{ Get-NinjaOneAlerts } | Should -Throw '*No alerts found*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+
+	It 'throws no-result device errors when the API returns null' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { $null }
+
+		{ Get-NinjaOneAlerts -deviceId 7 } | Should -Throw '*No alerts found for device 7*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+
 	It 'delegates upstream global request failures to New-NinjaOneError without masking' {
 		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { throw 'Not found' }
 
@@ -2902,6 +2916,20 @@ Describe 'Get-NinjaOneOrganisations' {
 		{ Get-NinjaOneOrganisations } | Should -Throw '*request-failed*'
 		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
 	}
+
+	It 'throws no-result organisation errors when the API returns null' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { $null }
+
+		{ Get-NinjaOneOrganisations } | Should -Throw '*No organisations found*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+
+	It 'throws no-result single organisation errors when the API returns null' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { $null }
+
+		{ Get-NinjaOneOrganisations -organisationId 21 } | Should -Throw '*Organisation with id 21 not found*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
 }
 
 Describe 'Get-NinjaOneLocations' {
@@ -3008,6 +3036,20 @@ Describe 'Get-NinjaOneDevices' {
 		}
 
 		{ Get-NinjaOneDevices -deviceId 7 } | Should -Throw '*request-failed*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+
+	It 'throws no-result global device errors when the API returns null' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { $null }
+
+		{ Get-NinjaOneDevices } | Should -Throw '*No devices found*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+
+	It 'throws no-result single device errors when the API returns null' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { $null }
+
+		{ Get-NinjaOneDevices -deviceId 7 } | Should -Throw '*Device with id 7 not found*'
 		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
 	}
 }
@@ -3175,6 +3217,13 @@ Describe 'Get-NinjaOneNotificationChannels' {
 		{ Get-NinjaOneNotificationChannels } | Should -Throw '*notification-request-failed*'
 		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
 	}
+
+	It 'throws no-result notification channel errors when the API returns null' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { $null }
+
+		{ Get-NinjaOneNotificationChannels } | Should -Throw '*No notification channels found*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
 }
 
 Describe 'Get-NinjaOneAutomations' {
@@ -3213,6 +3262,13 @@ Describe 'Get-NinjaOneAutomations' {
 		}
 
 		{ Get-NinjaOneAutomations } | Should -Throw '*automation-request-failed*'
+		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
+	}
+
+	It 'throws no-result automation errors when the API returns null' {
+		Mock -CommandName New-NinjaOneGETRequest -ModuleName $ModuleName -MockWith { $null }
+
+		{ Get-NinjaOneAutomations } | Should -Throw '*No automation scripts found*'
 		Assert-MockCalled -CommandName New-NinjaOneError -ModuleName $ModuleName -Times 1
 	}
 }


### PR DESCRIPTION
This pull request focuses on improving the reliability and clarity of connection and authentication checks in the NinjaOne PowerShell module, as well as ensuring that upstream request errors are surfaced accurately rather than being masked as generic "not found" errors. It also adds regression test coverage for these changes.

**Centralized connection/authentication checks:**

* The `Invoke-NinjaOneRequest` function now consistently invokes the shared `Invoke-NinjaOnePreFlightCheck` for all requests, ensuring that connection and authentication errors are handled in a single place. (`Source/Public/PSModule/Invoke/Invoke-NinjaOneRequest.ps1`, `Source/Private/Invoke-NinjaOnePreFlightCheck.ps1`, [[1]](diffhunk://#diff-299f0809f0a4323f5807fa16ea00faf75c8d280b441f32c2bfaad214aefa17ecL51-R51) [[2]](diffhunk://#diff-dd7d6adba422fd1b946a968719d292701f21e3b3854fb859b1436f21487f2fc2L32-R32)
* Updated the internal authentication variable from `$Script:NRAPIAuthToken` to `$Script:NRAPIAuthenticationInformation` for consistency across the codebase. (`Source/Private/Invoke-NinjaOnePreFlightCheck.ps1`, `Tests/NinjaOne.Private.Tests.ps1`, [[1]](diffhunk://#diff-dd7d6adba422fd1b946a968719d292701f21e3b3854fb859b1436f21487f2fc2L32-R32) [[2]](diffhunk://#diff-c771432e0fa0e7f2b55cde84a75a389a60e4fa8a55342521d8df35b0509dc57aL3054-R3054) [[3]](diffhunk://#diff-c771432e0fa0e7f2b55cde84a75a389a60e4fa8a55342521d8df35b0509dc57aL3071-R3071) [[4]](diffhunk://#diff-c771432e0fa0e7f2b55cde84a75a389a60e4fa8a55342521d8df35b0509dc57aL3080-R3080) [[5]](diffhunk://#diff-c771432e0fa0e7f2b55cde84a75a389a60e4fa8a55342521d8df35b0509dc57aL3094-R3093) [[6]](diffhunk://#diff-c771432e0fa0e7f2b55cde84a75a389a60e4fa8a55342521d8df35b0509dc57aL3103-R3102) [[7]](diffhunk://#diff-c771432e0fa0e7f2b55cde84a75a389a60e4fa8a55342521d8df35b0509dc57aL3113-R3162)

**Error handling improvements:**

* System `Get-*` cmdlets (such as `Get-NinjaOneAlerts`, `Get-NinjaOneDevices`, etc.) no longer mask upstream request failures as "No ... found" errors; instead, the real cause of the error is surfaced to the user, making troubleshooting easier. (`Source/Public/System/Get/Get-NinjaOneAlerts.ps1`, `Source/Public/System/Get/Get-NinjaOneDevices.ps1`, `Source/Public/System/Get/Get-NinjaOneOrganisations.ps1`, `Source/Public/System/Get/Get-NinjaOneNotificationChannels.ps1`, `Source/Public/System/Get/Get-NinjaOneAutomations.ps1`, [[1]](diffhunk://#diff-be56d4dfada78060cfd577ac2371b6c08aece169946da7b9bfb27d6d4194aec0L86-R94) [[2]](diffhunk://#diff-5b88747c90edaccb57b78e7994e9538b0b676841f0e45ce4ae84e12f12912098L147-R155) [[3]](diffhunk://#diff-787b429454d1f5195023e198ccf38b8dbab3cb404f9ef842e5cf8fcfabc45a38L96-R104) [[4]](diffhunk://#diff-f00b784c994fa1c39829f677f419a86221ddfb43860bd00f674242a455743485L56-R60) [[5]](diffhunk://#diff-f2da35c298859f0f45b3b815068f12b93af3352a93961cc0c78919685fd05905L51-R55)
* Updated tests to verify that upstream errors are no longer masked and are properly delegated to `New-NinjaOneError`. (`Tests/NinjaOne.Public.Tests.ps1`, [[1]](diffhunk://#diff-dc13b56e3c008aac9f55474d55066e2d44f99057afd1e2cc38abe15f0d040b00L2696-R2707) [[2]](diffhunk://#diff-dc13b56e3c008aac9f55474d55066e2d44f99057afd1e2cc38abe15f0d040b00L2897-R2902) [[3]](diffhunk://#diff-dc13b56e3c008aac9f55474d55066e2d44f99057afd1e2cc38abe15f0d040b00L3005-R3010) [[4]](diffhunk://#diff-dc13b56e3c008aac9f55474d55066e2d44f99057afd1e2cc38abe15f0d040b00L3175-R3175) [[5]](diffhunk://#diff-dc13b56e3c008aac9f55474d55066e2d44f99057afd1e2cc38abe15f0d040b00L3215-R3215)

**Regression test coverage:**

* Added new tests to ensure that the preflight check is always enforced in `Invoke-NinjaOneRequest` and that failures prevent downstream request execution. (`Tests/NinjaOne.Private.Tests.ps1`, [Tests/NinjaOne.Private.Tests.ps1L3113-R3162](diffhunk://#diff-c771432e0fa0e7f2b55cde84a75a389a60e4fa8a55342521d8df35b0509dc57aL3113-R3162))

**Versioning and documentation:**

* Bumped module version to `2.8.1` and updated the changelog to reflect these changes. (`Source/NinjaOne.psd1`, `CHANGELOG.md`, [[1]](diffhunk://#diff-311533e02cbcaeaf2c4c509c407336f450e6de7f22e0dad53f72714b08e97068L15-R15) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R15)

Fixes #91 