### PR TITLE
Upload public test coverage to Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,6 +239,14 @@ jobs:
           path: .artifacts/TestResults.private.xml
           reporter: java-junit
 
+      - name: Publish public test results
+        if: always()
+        uses: dorny/test-reporter@v3
+        with:
+          name: Pester Tests (Public)
+          path: .artifacts/TestResults.public.xml
+          reporter: java-junit
+
       - name: Publish docs test results
         if: always()
         uses: dorny/test-reporter@v3
@@ -255,6 +263,7 @@ jobs:
           path: |
             .artifacts/TestResults.core.xml
             .artifacts/TestResults.private.xml
+            .artifacts/TestResults.public.xml
             .artifacts/TestResults.docs.xml
 
       - name: Upload code coverage
@@ -265,6 +274,7 @@ jobs:
           path: |
             .artifacts/CodeCoverage.core.xml
             .artifacts/CodeCoverage.private.xml
+            .artifacts/CodeCoverage.public.xml
             .artifacts/CodeCoverage.docs.xml
 
       - name: Upload core coverage to Codecov
@@ -282,6 +292,15 @@ jobs:
         with:
           files: .artifacts/CodeCoverage.private.xml
           flags: private
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload public coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v6
+        with:
+          files: .artifacts/CodeCoverage.public.xml
+          flags: public
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -314,6 +333,18 @@ jobs:
           report_type: test_results
           flags: private
           name: pester-private
+          verbose: true
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload public test results to Codecov
+        if: always()
+        uses: codecov/codecov-action@v6
+        with:
+          files: .artifacts/TestResults.public.xml
+          report_type: test_results
+          flags: public
+          name: pester-public
           verbose: true
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/DevOps/Quality/generate-codecov-config.ps1
+++ b/DevOps/Quality/generate-codecov-config.ps1
@@ -146,6 +146,9 @@ $linesOut.Add('      - Source/Classes/**')
 $linesOut.Add('  private:')
 $linesOut.Add('    paths:')
 $linesOut.Add('      - Source/Private/**')
+$linesOut.Add('  public:')
+$linesOut.Add('    paths:')
+$linesOut.Add('      - Source/Public/**')
 
 $flagIds = @{}
 foreach ($folderName in $folderMappings.Keys) {

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,6 +8,9 @@ flags:
   private:
     paths:
       - Source/Private/**
+  public:
+    paths:
+      - Source/Public/**
   backup:
     paths:
       - 'Source/Public/Backup/**'
@@ -936,6 +939,7 @@ component_management:
       name: 'Functionality: Software License Assignments'
       paths:
         - Source/Public/ITAM/Get/Get-NinjaOneSoftwareLicenseAssignments.ps1
+        - Source/Public/ITAM/Set/Set-NinjaOneSoftwareLicenseAssignmentsLastUsage.ps1
     - component_id: func_software_licenses
       name: 'Functionality: Software Licenses'
       paths:
@@ -976,6 +980,10 @@ component_management:
       name: 'Functionality: Tab End User Order'
       paths:
         - Source/Public/Tabs/Set/Set-NinjaOneTabEndUserOrder.ps1
+    - component_id: func_tab_global_order
+      name: 'Functionality: Tab Global Order'
+      paths:
+        - Source/Public/Tabs/Set/Set-NinjaOneTabGlobalOrder.ps1
     - component_id: func_tab_organisation
       name: 'Functionality: Tab Organisation'
       paths:
@@ -1000,6 +1008,10 @@ component_management:
       name: 'Functionality: Tab Summary End User'
       paths:
         - Source/Public/Tabs/Get/Get-NinjaOneTabSummaryEndUser.ps1
+    - component_id: func_tab_summary_global
+      name: 'Functionality: Tab Summary Global'
+      paths:
+        - Source/Public/Tabs/Get/Get-NinjaOneTabSummaryGlobal.ps1
     - component_id: func_tab_summary_organisation
       name: 'Functionality: Tab Summary Organisation'
       paths:
@@ -1088,6 +1100,10 @@ component_management:
       paths:
         - Source/Public/Users/Add/Add-NinjaOneUserRoleMembers.ps1
         - Source/Public/Users/Remove/Remove-NinjaOneUserRoleMembers.ps1
+    - component_id: func_user_role_permissions
+      name: 'Functionality: User Role Permissions'
+      paths:
+        - Source/Public/Users/Set/Set-NinjaOneUserRoleOrganizationPermissions.ps1
     - component_id: func_user_roles
       name: 'Functionality: User Roles'
       paths:


### PR DESCRIPTION
Codecov reports roughly 1% coverage for `Source/Public` because CI generates the public coverage report but never uploads it.

This adds `CodeCoverage.public.xml` and `TestResults.public.xml` to workflow artifacts, publishes the public Pester results, uploads both reports to Codecov with a dedicated `public` flag, and keeps the generated Codecov configuration aligned with that flag.