### PR TITLE
Reserve fixed Codecov flag identifiers

### DIFF
--- a/DevOps/Quality/generate-codecov-config.ps1
+++ b/DevOps/Quality/generate-codecov-config.ps1
@@ -150,7 +150,11 @@ $linesOut.Add('  public:')
 $linesOut.Add('    paths:')
 $linesOut.Add('      - Source/Public/**')
 
-$flagIds = @{}
+$flagIds = @{
+	classes = $true
+	private = $true
+	public = $true
+}
 foreach ($folderName in $folderMappings.Keys) {
 	$flagId = ConvertTo-CodecovId -Name $folderName -Seen $flagIds
 	$pathPattern = $folderMappings[$folderName]

--- a/Tests/NinjaOne.Core.Tests.ps1
+++ b/Tests/NinjaOne.Core.Tests.ps1
@@ -23,6 +23,15 @@ BeforeAll {
 
 }
 
+Describe 'Codecov configuration generation' {
+	It 'reserves fixed flag identifiers before generating folder flags' {
+		$generatorPath = Join-Path -Path $PSScriptRoot -ChildPath '..\DevOps\Quality\generate-codecov-config.ps1'
+		$generatorContent = Get-Content -Path $generatorPath -Raw
+
+		$generatorContent | Should -Match '(?s)\$flagIds\s*=\s*@\{.*classes\s*=\s*\$true.*private\s*=\s*\$true.*public\s*=\s*\$true.*\}'
+	}
+}
+
 Describe ('{0} - Core Tests' -f $ModuleName) -Tags 'Module' {
     It 'Manifest is valid' {
         {

--- a/Tests/NinjaOne.Core.Tests.ps1
+++ b/Tests/NinjaOne.Core.Tests.ps1
@@ -28,7 +28,7 @@ Describe 'Codecov configuration generation' {
 		$generatorPath = Join-Path -Path $PSScriptRoot -ChildPath '..\DevOps\Quality\generate-codecov-config.ps1'
 		$generatorContent = Get-Content -Path $generatorPath -Raw
 
-		$generatorContent | Should -Match '(?s)\$flagIds\s*=\s*@\{.*classes\s*=\s*\$true.*private\s*=\s*\$true.*public\s*=\s*\$true.*\}'
+		$generatorContent | Should -Match '(?s)\$flagIds\s*=\s*@\{\s*(?=.*\bclasses\s*=\s*\$true)(?=.*\bprivate\s*=\s*\$true)(?=.*\bpublic\s*=\s*\$true).*?\}\s*foreach\s*\(\$folderName\s+in\s+\$folderMappings\.Keys\)'
 	}
 }
 


### PR DESCRIPTION
The Codecov generator tracks dynamically generated folder flags but did not reserve the fixed `classes`, `private`, and `public` identifiers first. A future folder collision could therefore produce duplicate YAML keys.

This seeds those reserved IDs before folder flag generation and adds a core regression test that protects the invariant.